### PR TITLE
fix: pylon doctor config 깊은 중첩 필드 누락 감지 수정

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -181,7 +181,7 @@ func SyncConfigDefaults(path string) (*Config, []string, error) {
 			continue
 		}
 
-		// Section exists — check sub-keys
+		// Section exists — recursively check sub-keys at all depths
 		defaultSub, ok := defaultVal.(map[string]any)
 		if !ok {
 			continue
@@ -191,25 +191,11 @@ func SyncConfigDefaults(path string) (*Config, []string, error) {
 			rawSub = make(map[string]any)
 		}
 
-		// Sort sub-keys for deterministic output
-		sortedSubKeys := make([]string, 0, len(defaultSub))
-		for k := range defaultSub {
-			sortedSubKeys = append(sortedSubKeys, k)
-		}
-		sort.Strings(sortedSubKeys)
-
-		keyHasMerge := false
-		for _, subKey := range sortedSubKeys {
-			if _, subExists := rawSub[subKey]; !subExists {
-				added = append(added, key+"."+subKey)
-				keyHasMerge = true
-				hasSubKeyMerge = true
-				rawSub[subKey] = defaultSub[subKey]
-			}
-		}
-
-		if keyHasMerge {
+		subAdded := findMissingFields(rawSub, defaultSub, key)
+		if len(subAdded) > 0 {
 			rawMap[key] = rawSub
+			added = append(added, subAdded...)
+			hasSubKeyMerge = true
 		}
 	}
 
@@ -239,6 +225,48 @@ func SyncConfigDefaults(path string) (*Config, []string, error) {
 	}
 
 	return cfg, added, nil
+}
+
+// findMissingFields recursively compares dst against defaults and merges
+// missing fields into dst. Returns a list of dotted field paths that were added.
+func findMissingFields(dst, defaults map[string]any, prefix string) []string {
+	var added []string
+
+	sortedKeys := make([]string, 0, len(defaults))
+	for k := range defaults {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	for _, key := range sortedKeys {
+		defaultVal := defaults[key]
+		path := prefix + "." + key
+
+		dstVal, exists := dst[key]
+		if !exists {
+			dst[key] = defaultVal
+			added = append(added, path)
+			continue
+		}
+
+		// If both are maps, recurse deeper
+		defaultSub, defaultIsMap := defaultVal.(map[string]any)
+		if !defaultIsMap {
+			continue
+		}
+		dstSub, dstIsMap := dstVal.(map[string]any)
+		if !dstIsMap {
+			dstSub = make(map[string]any)
+		}
+
+		subAdded := findMissingFields(dstSub, defaultSub, path)
+		if len(subAdded) > 0 {
+			dst[key] = dstSub
+			added = append(added, subAdded...)
+		}
+	}
+
+	return added
 }
 
 // LoadConfig reads and parses a config.yml file, applying defaults for missing fields.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -330,3 +330,236 @@ conversation:
 		})
 	}
 }
+
+func TestSyncConfigDefaults_DeepNestedMissing(t *testing.T) {
+	// Config with git.worktree section but missing auto_cleanup,
+	// and git.pr section but missing draft.
+	// These are depth-2 fields that the old code could not detect.
+	content := []byte(`version: "0.1"
+git:
+  branch_prefix: custom
+  default_base: develop
+  worktree:
+    enabled: true
+  pr:
+    auto_pr: true
+    reviewers:
+      - alice
+`)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(cfgPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, added, err := SyncConfigDefaults(cfgPath)
+	if err != nil {
+		t.Fatalf("SyncConfigDefaults failed: %v", err)
+	}
+
+	// Should detect git.worktree.auto_cleanup and git.pr.draft as missing
+	addedSet := make(map[string]bool)
+	for _, a := range added {
+		addedSet[a] = true
+	}
+
+	mustExist := []string{"git.worktree.auto_cleanup", "git.pr.draft"}
+	for _, field := range mustExist {
+		if !addedSet[field] {
+			t.Errorf("expected %q in added list, got: %v", field, added)
+		}
+	}
+
+	// Existing values must be preserved
+	if cfg.Git.BranchPrefix != "custom" {
+		t.Errorf("expected branch_prefix=custom, got %q", cfg.Git.BranchPrefix)
+	}
+	if cfg.Git.DefaultBase != "develop" {
+		t.Errorf("expected default_base=develop, got %q", cfg.Git.DefaultBase)
+	}
+	if !cfg.Git.Worktree.Enabled {
+		t.Error("expected worktree.enabled=true to be preserved")
+	}
+	if !cfg.Git.PR.AutoPR {
+		t.Error("expected pr.auto_pr=true to be preserved")
+	}
+
+	// Verify the file was rewritten with missing fields
+	reloaded, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig after sync failed: %v", err)
+	}
+	if !reloaded.Git.Worktree.AutoCleanup {
+		t.Error("expected worktree.auto_cleanup=true in rewritten file")
+	}
+}
+
+func TestSyncConfigDefaults_EntireSectionMissing(t *testing.T) {
+	// Config with only version and runtime — skills section entirely missing.
+	// Should be appended (not rewrite) and detected.
+	content := []byte(`version: "0.1"
+runtime:
+  backend: claude-code
+  max_concurrent: 5
+  task_timeout: 30m
+  max_attempts: 2
+  max_turns: 50
+  permission_mode: acceptEdits
+  env:
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: "80"
+    CLAUDE_CODE_EFFORT_LEVEL: high
+git:
+  branch_prefix: task
+  default_base: main
+  auto_push: true
+  worktree:
+    enabled: true
+    auto_cleanup: true
+  pr:
+    auto_pr: false
+    draft: false
+wiki:
+  auto_update: true
+  update_on:
+    - task_complete
+    - pr_merged
+memory:
+  compaction_threshold: 0.7
+  proactive_injection: true
+  proactive_max_tokens: 2000
+  session_archive: true
+conversation:
+  retention_days: 90
+workflow:
+  default_workflow: feature
+ontology:
+  package_name: pylon-ontology
+  auto_extract: true
+  auto_verify: true
+`)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(cfgPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, added, err := SyncConfigDefaults(cfgPath)
+	if err != nil {
+		t.Fatalf("SyncConfigDefaults failed: %v", err)
+	}
+
+	// skills section is entirely missing — should be detected
+	addedSet := make(map[string]bool)
+	for _, a := range added {
+		addedSet[a] = true
+	}
+
+	if !addedSet["skills"] {
+		t.Errorf("expected 'skills' in added list, got: %v", added)
+	}
+}
+
+func TestSyncConfigDefaults_NoChangesOnSecondSync(t *testing.T) {
+	// Minimal config → first sync adds defaults → second sync should find no changes.
+	content := []byte(`version: "0.1"`)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yml")
+	if err := os.WriteFile(cfgPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First sync: adds all missing defaults
+	_, firstAdded, err := SyncConfigDefaults(cfgPath)
+	if err != nil {
+		t.Fatalf("first SyncConfigDefaults failed: %v", err)
+	}
+	if len(firstAdded) == 0 {
+		t.Fatal("expected first sync to add fields for minimal config")
+	}
+
+	// Second sync: should find nothing missing
+	_, secondAdded, err := SyncConfigDefaults(cfgPath)
+	if err != nil {
+		t.Fatalf("second SyncConfigDefaults failed: %v", err)
+	}
+	if len(secondAdded) != 0 {
+		t.Errorf("expected no changes on second sync, got added: %v", secondAdded)
+	}
+}
+
+func TestFindMissingFields_Recursive(t *testing.T) {
+	defaults := map[string]any{
+		"a": "val_a",
+		"b": map[string]any{
+			"b1": "val_b1",
+			"b2": map[string]any{
+				"b2a": "val_b2a",
+				"b2b": "val_b2b",
+			},
+		},
+	}
+
+	dst := map[string]any{
+		"a": "custom_a",
+		"b": map[string]any{
+			"b1": "custom_b1",
+			"b2": map[string]any{
+				"b2a": "custom_b2a",
+				// b2b is missing
+			},
+		},
+	}
+
+	added := findMissingFields(dst, defaults, "root")
+
+	if len(added) != 1 {
+		t.Fatalf("expected 1 added field, got %d: %v", len(added), added)
+	}
+	if added[0] != "root.b.b2.b2b" {
+		t.Errorf("expected root.b.b2.b2b, got %q", added[0])
+	}
+
+	// Verify the value was merged
+	b := dst["b"].(map[string]any)
+	b2 := b["b2"].(map[string]any)
+	if b2["b2b"] != "val_b2b" {
+		t.Errorf("expected b2b=val_b2b, got %v", b2["b2b"])
+	}
+	// Existing value must be preserved
+	if b2["b2a"] != "custom_b2a" {
+		t.Errorf("expected b2a=custom_b2a preserved, got %v", b2["b2a"])
+	}
+}
+
+func TestFindMissingFields_TypeMismatchGuard(t *testing.T) {
+	// When user writes a scalar where a map is expected (e.g., worktree: true),
+	// findMissingFields should still fill in default sub-keys.
+	defaults := map[string]any{
+		"nested": map[string]any{
+			"child_a": "val_a",
+			"child_b": "val_b",
+		},
+	}
+
+	dst := map[string]any{
+		"nested": "scalar_value", // wrong type: scalar instead of map
+	}
+
+	added := findMissingFields(dst, defaults, "root")
+
+	if len(added) != 2 {
+		t.Fatalf("expected 2 added fields, got %d: %v", len(added), added)
+	}
+
+	// dst["nested"] should now be a map with defaults
+	nested, ok := dst["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected dst[nested] to be map, got %T", dst["nested"])
+	}
+	if nested["child_a"] != "val_a" || nested["child_b"] != "val_b" {
+		t.Errorf("expected default sub-keys, got %v", nested)
+	}
+}


### PR DESCRIPTION
## Summary
- `SyncConfigDefaults`가 depth-1 sub-key까지만 검사하여 `git.worktree.auto_cleanup`, `git.pr.draft` 같은 depth-2+ 중첩 필드 누락을 감지하지 못하는 버그 수정
- 재귀적 `findMissingFields` 헬퍼를 추가하여 임의 깊이의 중첩 필드를 비교하도록 변경
- 기존 동작(전체 섹션 누락 시 append 모드, 사용자 값 보존) 유지

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `internal/config/config.go` | flat sub-key loop → 재귀적 `findMissingFields` 호출로 교체 |
| `internal/config/config_test.go` | 5개 테스트 추가 (deep nested, 전체 섹션, 멱등성, 재귀 단위, type mismatch) |

## Test plan
- [x] `go build ./...` 성공
- [x] `go test ./...` 전체 11 패키지 통과
- [x] `TestSyncConfigDefaults_DeepNestedMissing` — git.worktree.auto_cleanup, git.pr.draft 누락 감지 확인
- [x] `TestSyncConfigDefaults_EntireSectionMissing` — 전체 섹션 누락 감지 (회귀 없음)
- [x] `TestSyncConfigDefaults_NoChangesOnSecondSync` — 이중 sync 멱등성 확인
- [x] `TestFindMissingFields_Recursive` — depth-3 재귀 감지 + 기존 값 보존
- [x] `TestFindMissingFields_TypeMismatchGuard` — 스칼라/맵 타입 불일치 방어