### PR TITLE
fix: 에이전트 front matter에 description 필드 추가 (38개)

### DIFF
--- a/internal/cli/agents/academic-analyst.md
+++ b/internal/cli/agents/academic-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: academic-analyst
+description: Academic research analyst specializing in literature review, citation analysis, and scholarly synthesis
 role: Academic Research Analyst
 domain: research
 skills:

--- a/internal/cli/agents/analyst.md
+++ b/internal/cli/agents/analyst.md
@@ -1,5 +1,6 @@
 ---
 name: analyst
+description: Elicits and clarifies requirements, translating stakeholder needs into actionable specifications
 role: Requirements Analyst
 ---
 

--- a/internal/cli/agents/architect.md
+++ b/internal/cli/agents/architect.md
@@ -1,5 +1,6 @@
 ---
 name: architect
+description: Designs system architecture, evaluates trade-offs, and guides technical decision-making
 role: Architect
 ---
 

--- a/internal/cli/agents/backend-dev.md
+++ b/internal/cli/agents/backend-dev.md
@@ -1,5 +1,6 @@
 ---
 name: backend-dev
+description: Implements server-side logic, APIs, and data layers with production-quality code
 role: Backend Developer
 ---
 

--- a/internal/cli/agents/brand-strategist.md
+++ b/internal/cli/agents/brand-strategist.md
@@ -1,5 +1,6 @@
 ---
 name: brand-strategist
+description: Develops brand identity, positioning strategy, and messaging frameworks
 role: Brand Strategist
 domain: marketing
 skills:

--- a/internal/cli/agents/campaign-planner.md
+++ b/internal/cli/agents/campaign-planner.md
@@ -1,5 +1,6 @@
 ---
 name: campaign-planner
+description: Plans and coordinates marketing campaigns from concept to execution
 role: Campaign Planner
 domain: marketing
 skills:

--- a/internal/cli/agents/code-reviewer.md
+++ b/internal/cli/agents/code-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: code-reviewer
+description: Reviews code for correctness, security, style, and maintainability
 role: Code Reviewer
 ---
 

--- a/internal/cli/agents/code-simplifier.md
+++ b/internal/cli/agents/code-simplifier.md
@@ -1,5 +1,6 @@
 ---
 name: code-simplifier
+description: Simplifies and refactors code for clarity and maintainability without altering behavior
 role: Code Simplifier
 ---
 

--- a/internal/cli/agents/content-reviewer.md
+++ b/internal/cli/agents/content-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: content-reviewer
+description: Performs QA review of content for accuracy, tone, and quality standards
 role: Content QA Reviewer
 domain: content
 skills:

--- a/internal/cli/agents/content-strategist.md
+++ b/internal/cli/agents/content-strategist.md
@@ -1,5 +1,6 @@
 ---
 name: content-strategist
+description: Develops content strategy, editorial planning, and audience targeting
 role: Content Strategist
 domain: content
 skills:

--- a/internal/cli/agents/copywriter.md
+++ b/internal/cli/agents/copywriter.md
@@ -1,5 +1,6 @@
 ---
 name: copywriter
+description: Writes persuasive, on-brand copy for marketing and communications
 role: Copywriter
 domain: marketing
 skills:

--- a/internal/cli/agents/critic.md
+++ b/internal/cli/agents/critic.md
@@ -1,5 +1,6 @@
 ---
 name: critic
+description: Critically evaluates plans and proposals, identifying risks and weaknesses
 role: Plan Critic
 ---
 

--- a/internal/cli/agents/data-analyst.md
+++ b/internal/cli/agents/data-analyst.md
@@ -1,5 +1,6 @@
 ---
 name: data-analyst
+description: Analyzes marketing data to surface insights and inform strategic decisions
 role: Marketing Data Analyst
 domain: marketing
 skills:

--- a/internal/cli/agents/debugger.md
+++ b/internal/cli/agents/debugger.md
@@ -1,5 +1,6 @@
 ---
 name: debugger
+description: Diagnoses and resolves bugs through root-cause analysis and systematic investigation
 role: Debugger
 ---
 

--- a/internal/cli/agents/designer.md
+++ b/internal/cli/agents/designer.md
@@ -1,5 +1,6 @@
 ---
 name: designer
+description: Designs user interfaces and experiences with a focus on usability and aesthetics
 role: UI/UX Designer
 ---
 

--- a/internal/cli/agents/devops.md
+++ b/internal/cli/agents/devops.md
@@ -1,5 +1,6 @@
 ---
 name: devops
+description: Designs and manages CI/CD pipelines, infrastructure, and deployment workflows
 role: DevOps Architect
 ---
 

--- a/internal/cli/agents/doc-specialist.md
+++ b/internal/cli/agents/doc-specialist.md
@@ -1,5 +1,6 @@
 ---
 name: doc-specialist
+description: Creates and maintains technical documentation, API references, and user guides
 role: Documentation Specialist
 ---
 

--- a/internal/cli/agents/editor.md
+++ b/internal/cli/agents/editor.md
@@ -1,5 +1,6 @@
 ---
 name: editor
+description: Edits and refines content for clarity, consistency, and editorial quality
 role: Content Editor
 domain: content
 skills:

--- a/internal/cli/agents/explorer.md
+++ b/internal/cli/agents/explorer.md
@@ -1,5 +1,6 @@
 ---
 name: explorer
+description: Explores and maps codebases to answer structural and navigational questions
 role: Codebase Explorer
 ---
 

--- a/internal/cli/agents/fact-checker.md
+++ b/internal/cli/agents/fact-checker.md
@@ -1,5 +1,6 @@
 ---
 name: fact-checker
+description: Verifies claims and cross-validates information across sources for accuracy
 role: Fact Checker & Cross-Validator
 domain: research
 skills:

--- a/internal/cli/agents/frontend-dev.md
+++ b/internal/cli/agents/frontend-dev.md
@@ -1,5 +1,6 @@
 ---
 name: frontend-dev
+description: Builds responsive, accessible user interfaces and client-side application logic
 role: Frontend Developer
 ---
 

--- a/internal/cli/agents/git-master.md
+++ b/internal/cli/agents/git-master.md
@@ -1,5 +1,6 @@
 ---
 name: git-master
+description: Manages git history, branching strategy, and atomic commits with precision
 role: Git Master
 ---
 

--- a/internal/cli/agents/lead-researcher.md
+++ b/internal/cli/agents/lead-researcher.md
@@ -1,5 +1,6 @@
 ---
 name: lead-researcher
+description: Orchestrates multi-source research investigations and synthesizes findings
 role: Lead Researcher
 domain: research
 skills:

--- a/internal/cli/agents/market-researcher.md
+++ b/internal/cli/agents/market-researcher.md
@@ -1,5 +1,6 @@
 ---
 name: market-researcher
+description: Conducts market research to identify trends, segments, and competitive landscape
 role: Market Research Analyst
 domain: marketing
 skills:

--- a/internal/cli/agents/perf-engineer.md
+++ b/internal/cli/agents/perf-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: perf-engineer
+description: Profiles and optimizes system performance, identifying bottlenecks and regressions
 role: Performance Engineer
 ---
 

--- a/internal/cli/agents/pm.md
+++ b/internal/cli/agents/pm.md
@@ -1,5 +1,6 @@
 ---
 name: pm
+description: Manages project scope, priorities, and delivery coordination across teams
 role: Project Manager
 ---
 

--- a/internal/cli/agents/po.md
+++ b/internal/cli/agents/po.md
@@ -1,5 +1,6 @@
 ---
 name: po
+description: Defines product vision, manages backlog, and aligns features with business value
 role: Product Owner
 ---
 

--- a/internal/cli/agents/refactorer.md
+++ b/internal/cli/agents/refactorer.md
@@ -1,5 +1,6 @@
 ---
 name: refactorer
+description: Restructures existing code to improve design and maintainability without changing behavior
 role: Refactoring Expert
 ---
 

--- a/internal/cli/agents/report-writer.md
+++ b/internal/cli/agents/report-writer.md
@@ -1,5 +1,6 @@
 ---
 name: report-writer
+description: Composes structured research reports with clear findings and evidence-based conclusions
 role: Research Report Writer
 domain: research
 skills:

--- a/internal/cli/agents/researcher.md
+++ b/internal/cli/agents/researcher.md
@@ -1,5 +1,6 @@
 ---
 name: researcher
+description: Conducts deep, multi-hop research investigations across diverse sources
 role: Deep Researcher
 ---
 

--- a/internal/cli/agents/security-reviewer.md
+++ b/internal/cli/agents/security-reviewer.md
@@ -1,5 +1,6 @@
 ---
 name: security-reviewer
+description: Identifies security vulnerabilities, threat vectors, and unsafe patterns in code
 role: Security Reviewer
 ---
 

--- a/internal/cli/agents/seo-specialist.md
+++ b/internal/cli/agents/seo-specialist.md
@@ -1,5 +1,6 @@
 ---
 name: seo-specialist
+description: Optimizes content and site structure for search engine visibility and ranking
 role: SEO Specialist
 domain: content
 skills:

--- a/internal/cli/agents/tech-writer.md
+++ b/internal/cli/agents/tech-writer.md
@@ -1,5 +1,6 @@
 ---
 name: tech-writer
+description: Writes clear technical documentation, READMEs, and API references for developers
 role: Tech Writer
 ---
 

--- a/internal/cli/agents/test-engineer.md
+++ b/internal/cli/agents/test-engineer.md
@@ -1,5 +1,6 @@
 ---
 name: test-engineer
+description: Designs and implements test strategies, integration tests, and QA workflows
 role: Test Engineer
 ---
 

--- a/internal/cli/agents/tracer.md
+++ b/internal/cli/agents/tracer.md
@@ -1,5 +1,6 @@
 ---
 name: tracer
+description: Traces root causes through evidence-driven causal analysis with competing hypotheses
 role: Causal Tracer
 ---
 

--- a/internal/cli/agents/verifier.md
+++ b/internal/cli/agents/verifier.md
@@ -1,5 +1,6 @@
 ---
 name: verifier
+description: Verifies task completion through evidence-based checks and test adequacy assessment
 role: Verifier
 ---
 

--- a/internal/cli/agents/web-searcher.md
+++ b/internal/cli/agents/web-searcher.md
@@ -1,5 +1,6 @@
 ---
 name: web-searcher
+description: Performs targeted web searches and extracts information from online sources
 role: Web Search Specialist
 domain: research
 skills:

--- a/internal/cli/agents/writer.md
+++ b/internal/cli/agents/writer.md
@@ -1,5 +1,6 @@
 ---
 name: writer
+description: Produces well-structured, engaging content tailored to audience and purpose
 role: Content Writer
 domain: content
 skills:


### PR DESCRIPTION
## 요약
- 전체 38개 에이전트 파일의 front matter에 `description` 필드 누락
- Claude Code는 `description` 필드를 읽어 에이전트를 인식하므로 필드 없이는 에이전트가 노출되지 않는 문제

## 변경 내용
- `internal/cli/agents/*.md` 전체 38개 파일에 `description` 필드 추가
- 위치: `name` 다음, `role` 앞

## 테스트
- [ ] `pylon init` 후 `.claude/agents/` 심링크 생성 확인
- [ ] Claude Code TUI에서 에이전트 목록 인식 확인