### PR TITLE
feat: AgentConfig에 description 필드 추가 (#18)

### DIFF
--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -13,6 +13,7 @@ import (
 type AgentConfig struct {
 	// YAML frontmatter fields (between --- delimiters)
 	Name           string            `yaml:"name"`
+	Description    string            `yaml:"description"`
 	Role           string            `yaml:"role"`
 	Type           string            `yaml:"type"`
 	Backend        string            `yaml:"backend"`

--- a/internal/config/agent_test.go
+++ b/internal/config/agent_test.go
@@ -18,6 +18,7 @@ func TestParseAgentFile_FullAgent(t *testing.T) {
 		expected interface{}
 	}{
 		{"name", agent.Name, "backend-dev"},
+		{"description", agent.Description, "Implements project-api backend features following Go standard project layout"},
 		{"role", agent.Role, "Backend Developer"},
 		{"backend", agent.Backend, "claude-code"},
 		{"maxTurns", agent.MaxTurns, 30},
@@ -77,6 +78,9 @@ func TestParseAgentFile_ArchitectAgent(t *testing.T) {
 
 	if agent.Name != "architect" {
 		t.Errorf("name: got %q, expected %q", agent.Name, "architect")
+	}
+	if agent.Description != "Read-only solution architect that produces design documents and ADRs" {
+		t.Errorf("description: got %q", agent.Description)
 	}
 	if agent.Role != "Solution Architect" {
 		t.Errorf("role: got %q, expected %q", agent.Role, "Solution Architect")
@@ -148,6 +152,9 @@ func TestParseAgentFile_MinimalAgent(t *testing.T) {
 	}
 
 	// Optional fields should be zero-valued
+	if agent.Description != "" {
+		t.Errorf("description should be empty, got %q", agent.Description)
+	}
 	if agent.Backend != "" {
 		t.Errorf("backend should be empty, got %q", agent.Backend)
 	}

--- a/testdata/agents/architect.md
+++ b/testdata/agents/architect.md
@@ -1,5 +1,6 @@
 ---
 name: architect
+description: Read-only solution architect that produces design documents and ADRs
 role: Solution Architect
 backend: claude-code
 scope:

--- a/testdata/agents/backend-dev.md
+++ b/testdata/agents/backend-dev.md
@@ -1,5 +1,6 @@
 ---
 name: backend-dev
+description: Implements project-api backend features following Go standard project layout
 role: Backend Developer
 backend: claude-code
 scope:

--- a/testdata/agents/po.md
+++ b/testdata/agents/po.md
@@ -1,5 +1,6 @@
 ---
 name: po
+description: Clarifies user requirements and gates execution by computing an ambiguity score
 role: Product Owner
 backend: claude-code
 maxTurns: 50


### PR DESCRIPTION
## 요약

[#18](https://github.com/kyago/pylon/issues/18)의 미완료 항목을 처리합니다. PR #66에서 `internal/cli/agents/`의 38개 에이전트 frontmatter에 `description`이 추가되었지만, `AgentConfig` Go 구조체에는 필드가 없어 yaml 파싱 시 silently drop되던 문제를 해결합니다.

## 변경 사항

- `AgentConfig` 구조체에 `Description string \`yaml:\"description\"\`` 필드 추가 (`internal/config/agent.go`)
- testdata 샘플 에이전트 frontmatter에 `description` 추가 (`po.md`, `architect.md`, `backend-dev.md`)
- 파싱 테스트에 description 필드 검증 케이스 추가 (`agent_test.go`)
  - FullAgent: backend-dev description 값 검증
  - ArchitectAgent: architect description 값 검증
  - MinimalAgent: description 미지정 시 zero-value("") 검증

## 이슈 #18 체크리스트 갱신

- [x] `AgentConfig` 구조체에 `description` 필드 추가
- [x] `ParseAgentFile` 및 관련 로직에서 `description` 처리 (yaml 태그로 자동 처리)
- [x] 기존 샘플 에이전트에 `description` 추가 (PR #66에서 `internal/cli/agents/`, 본 PR에서 `testdata/agents/`)
- [x] 신규 에이전트 5/6 작성 (analyst, architect, code-reviewer, debugger, critic — `planner` 역할은 기존 `pm` 에이전트가 커버)
- [x] 에이전트 파싱 테스트 업데이트
- [x] `pylon init` 시 기본 에이전트 복사 로직 (`writeAgentTemplates`)
- [x] README 기본 에이전트 팩 문서

## 테스트

- [x] `go test ./internal/config/ -run TestParseAgent -v` — 모두 통과
- [x] `go build ./...` — 빌드 성공
- [x] `go test ./...` — 전체 테스트 회귀 없음