### PR TITLE
fix: 버전업 시 pl 내장 리소스가 갱신되지 않던 동기화 수정

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
 	"os"
@@ -8,16 +9,16 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/spf13/cobra"
 	"github.com/kyago/pylon/internal/config"
+	"github.com/spf13/cobra"
 )
 
 // Check represents a single dependency check.
 // Spec Reference: Section 7 "pylon doctor"
 type Check struct {
-	Name     string
-	Required bool
-	Verify   func() (version string, err error)
+	Name       string
+	Required   bool
+	Verify     func() (version string, err error)
 	InstallURL string
 }
 
@@ -288,7 +289,9 @@ func syncConfigIfWorkspace() {
 
 // syncResourcesIfWorkspace syncs embedded agents, skills, commands, and scripts
 // to the workspace if running inside a pylon workspace.
-// New files are installed; existing files are skipped to preserve user customizations.
+// .pylon/ resources are pylon-managed: missing files are installed and files
+// whose content differs from the embedded version are refreshed, so upgrades
+// pick up new resource content.
 func syncResourcesIfWorkspace() {
 	startDir := flagWorkspace
 	if startDir == "" {
@@ -300,23 +303,19 @@ func syncResourcesIfWorkspace() {
 	}
 
 	pylonDir := filepath.Join(root, ".pylon")
-	var totalInstalled int
+	var totalWritten int
 
 	// Sync agents
-	installed := syncEmbeddedDir(embeddedAgents, "agents", filepath.Join(pylonDir, "agents"), ".md")
-	totalInstalled += installed
+	totalWritten += syncEmbeddedDir(embeddedAgents, "agents", filepath.Join(pylonDir, "agents"), ".md")
 
 	// Sync skills
-	installed = syncEmbeddedDir(embeddedSkills, "skills", filepath.Join(pylonDir, "skills"), ".md")
-	totalInstalled += installed
+	totalWritten += syncEmbeddedDir(embeddedSkills, "skills", filepath.Join(pylonDir, "skills"), ".md")
 
 	// Sync commands
-	installed = syncEmbeddedDir(embeddedCommands, "commands", filepath.Join(pylonDir, "commands"), ".md")
-	totalInstalled += installed
+	totalWritten += syncEmbeddedDir(embeddedCommands, "commands", filepath.Join(pylonDir, "commands"), ".md")
 
 	// Sync scripts
-	installed = syncEmbeddedDir(embeddedScripts, "scripts/bash", filepath.Join(pylonDir, "scripts", "bash"), ".sh")
-	totalInstalled += installed
+	totalWritten += syncEmbeddedDir(embeddedScripts, "scripts/bash", filepath.Join(pylonDir, "scripts", "bash"), ".sh")
 
 	// Update .claude/agents/ with skill injection (consistent with pylon launch)
 	cfg, err := config.LoadConfig(filepath.Join(pylonDir, "config.yml"))
@@ -331,16 +330,18 @@ func syncResourcesIfWorkspace() {
 		}
 	}
 
-	if totalInstalled > 0 {
-		fmt.Printf("✓ 내장 리소스 %d개 신규 설치\n", totalInstalled)
+	if totalWritten > 0 {
+		fmt.Printf("✓ 내장 리소스 %d개 설치/갱신\n", totalWritten)
 	} else {
 		fmt.Println("✓ 내장 리소스 최신 상태")
 	}
 }
 
 // syncEmbeddedDir copies files from an embed.FS subdirectory to a target directory.
-// Only new files are installed; existing files are skipped.
-// Returns the number of newly installed files.
+// .pylon/ resources are treated as pylon-managed: a file is written when it is
+// missing or when its on-disk content differs from the embedded version, so that
+// version upgrades refresh stale files. Unchanged files are left untouched.
+// Returns the number of files written (newly installed or refreshed).
 func syncEmbeddedDir(fs embed.FS, embedDir, targetDir, suffix string) int {
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		fmt.Printf("⚠ %s 디렉토리 생성 실패: %v\n", targetDir, err)
@@ -353,19 +354,19 @@ func syncEmbeddedDir(fs embed.FS, embedDir, targetDir, suffix string) int {
 		return 0
 	}
 
-	installed := 0
+	written := 0
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), suffix) {
 			continue // 비재귀: 서브디렉토리 스킵 (현재 리소스 구조에서는 불필요)
-		}
-		destPath := filepath.Join(targetDir, entry.Name())
-		if _, err := os.Stat(destPath); err == nil {
-			continue // already exists, skip
 		}
 		content, err := fs.ReadFile(embedDir + "/" + entry.Name())
 		if err != nil {
 			fmt.Printf("⚠ %s 읽기 실패: %v\n", entry.Name(), err)
 			continue
+		}
+		destPath := filepath.Join(targetDir, entry.Name())
+		if existing, err := os.ReadFile(destPath); err == nil && bytes.Equal(existing, content) {
+			continue // 디스크 내용이 내장 버전과 동일 — 갱신 불필요
 		}
 		perm := os.FileMode(0644)
 		if suffix == ".sh" {
@@ -375,9 +376,9 @@ func syncEmbeddedDir(fs embed.FS, embedDir, targetDir, suffix string) int {
 			fmt.Printf("⚠ %s 쓰기 실패: %v\n", entry.Name(), err)
 			continue
 		}
-		installed++
+		written++
 	}
-	return installed
+	return written
 }
 
 func verifyClaude() (string, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +10,71 @@ import (
 
 	"github.com/kyago/pylon/internal/config"
 )
+
+// firstEmbeddedSkill returns the name of the first embedded skill .md file,
+// skipping the test if none are present.
+func firstEmbeddedSkill(t *testing.T) string {
+	t.Helper()
+	entries, err := embeddedSkills.ReadDir("skills")
+	if err != nil {
+		t.Fatalf("read embedded skills: %v", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+			return e.Name()
+		}
+	}
+	t.Skip("no embedded skill files available to test")
+	return ""
+}
+
+// TestSyncEmbeddedDir_RefreshesStaleFile reproduces the version-upgrade bug:
+// an existing file with outdated content (from a previous pylon version) must
+// be refreshed to the embedded content, not silently skipped.
+func TestSyncEmbeddedDir_RefreshesStaleFile(t *testing.T) {
+	targetDir := t.TempDir()
+	name := firstEmbeddedSkill(t)
+
+	want, err := embeddedSkills.ReadFile("skills/" + name)
+	if err != nil {
+		t.Fatalf("read embedded file: %v", err)
+	}
+
+	// Pre-seed a stale version, simulating a file installed by an older pylon.
+	destPath := filepath.Join(targetDir, name)
+	if err := os.WriteFile(destPath, []byte("STALE OLD VERSION\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed := syncEmbeddedDir(embeddedSkills, "skills", targetDir, ".md")
+
+	got, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("stale file %s was not refreshed to embedded content", name)
+	}
+	if changed == 0 {
+		t.Errorf("expected changed count > 0 when a stale file is refreshed, got 0")
+	}
+}
+
+// TestSyncEmbeddedDir_SkipsUnchangedFile verifies that re-syncing identical
+// content reports no changes (idempotent, no needless rewrites).
+func TestSyncEmbeddedDir_SkipsUnchangedFile(t *testing.T) {
+	targetDir := t.TempDir()
+
+	first := syncEmbeddedDir(embeddedSkills, "skills", targetDir, ".md")
+	if first == 0 {
+		t.Fatal("expected files to be installed on first sync")
+	}
+
+	second := syncEmbeddedDir(embeddedSkills, "skills", targetDir, ".md")
+	if second != 0 {
+		t.Errorf("expected 0 changes on second sync of identical content, got %d", second)
+	}
+}
 
 func TestCheckExcludeStatus(t *testing.T) {
 	requireGit(t)

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -703,6 +703,12 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 		// 심링크는 제거하고 최신 주입 내용으로 재생성한다. 일반 파일은 pylon이
 		// 생성한 주입 파일(주입 마커 포함)만 갱신하고, 마커가 없는(사용자가 직접
 		// 작성한) 파일은 보존한다. 이미 최신 내용이면 다시 쓰지 않는다.
+		//
+		// 계약: 주입 마커를 포함한 .claude/agents/ 파일은 pylon 소유로 간주되며,
+		// 사용자가 이 파일을 직접 수정하더라도(마커가 남아 있는 한) update 시
+		// 최신 주입 내용으로 덮어써진다. 에이전트 커스터마이징은 .claude/agents/가
+		// 아니라 .pylon/agents/ 또는 .pylon/skills/에서 해야 한다. 마커가 없는
+		// 파일(사용자가 처음부터 작성한 에이전트)은 절대 덮어쓰지 않는다.
 		if info, err := os.Lstat(linkPath); err == nil {
 			if info.Mode()&os.ModeSymlink != 0 {
 				os.Remove(linkPath)
@@ -725,6 +731,11 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 	// Only symlinks are removed — pylon-generated regular files (from skill injection) are
 	// left in place because they cannot be reliably distinguished from user-created files
 	// without a manifest. This is a known limitation; a manifest-based approach can be added later.
+	//
+	// Related known gap: if an agent that still exists in .pylon/agents/ loses all of its
+	// skills between versions, it routes to the ensureSymlink path above, which does not
+	// touch existing regular files — so a previously injected (marker-bearing) regular file
+	// is left with stale content until manually removed. Not data loss; same manifest limitation.
 	claudeEntries, err := os.ReadDir(claudeAgentsDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "경고: .claude/agents/ 읽기 실패: %v\n", err)

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -89,7 +89,6 @@ func runLaunch() error {
 	return syscall.Exec(claudePath, args, env)
 }
 
-
 // openWorkspaceStore is a shared helper that finds the workspace root, loads config,
 // and opens the SQLite store. Caller must close the returned Store.
 func openWorkspaceStore() (string, *config.Config, *store.Store, error) {
@@ -594,7 +593,6 @@ func buildSlashCommands(root string) map[string]string {
 	return commands
 }
 
-
 // addToGitignore appends pylon-managed entries to .gitignore if not already present.
 func addClaudeDirToGitignore(root string) error {
 	gitignorePath := filepath.Join(root, ".gitignore")
@@ -701,13 +699,21 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 		// Append skill section to agent content
 		combined := string(content) + "\n\n" + injected
 
-		// Remove existing symlink only; preserve user-created regular files
+		// linkPath의 이름은 .pylon/agents/ 기반이므로 pylon 관리 에이전트다.
+		// 심링크는 제거하고 최신 주입 내용으로 재생성한다. 일반 파일은 pylon이
+		// 생성한 주입 파일(주입 마커 포함)만 갱신하고, 마커가 없는(사용자가 직접
+		// 작성한) 파일은 보존한다. 이미 최신 내용이면 다시 쓰지 않는다.
 		if info, err := os.Lstat(linkPath); err == nil {
 			if info.Mode()&os.ModeSymlink != 0 {
 				os.Remove(linkPath)
 			} else {
-				// Regular file exists — don't overwrite user files
-				continue
+				existing, rerr := os.ReadFile(linkPath)
+				if rerr != nil || !strings.Contains(string(existing), skillInjectionMarker) {
+					continue // 사용자 작성 파일(주입 마커 없음) — 보존
+				}
+				if string(existing) == combined {
+					continue // 이미 최신 주입 내용 — 갱신 불필요
+				}
 			}
 		}
 		if err := os.WriteFile(linkPath, []byte(combined), 0644); err != nil {
@@ -745,6 +751,12 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 	return nil
 }
 
+// skillInjectionMarker is the header that marks a .claude/agents/ file as
+// pylon-generated with injected skill content. It is used to distinguish
+// pylon-managed injected files (safe to refresh on upgrade) from files a user
+// authored by hand (preserved).
+const skillInjectionMarker = "## 주입된 스킬"
+
 // buildSkillInjection generates the skill content to inject into an agent file.
 // If progressiveDisclosure is true, only metadata (name + description) is injected.
 // If false, the full skill body is injected.
@@ -759,7 +771,7 @@ func buildSkillInjection(skillNames []string, skillMap map[string]*config.SkillC
 		}
 
 		if !injected {
-			b.WriteString("## 주입된 스킬\n\n")
+			b.WriteString(skillInjectionMarker + "\n\n")
 			injected = true
 		}
 
@@ -830,7 +842,7 @@ type settingsHookCommand struct {
 // settingsHookEntry represents a hook group in .claude/settings.json.
 // Each group has a matcher string and an array of hook commands.
 type settingsHookEntry struct {
-	Matcher string               `json:"matcher"`
+	Matcher string                `json:"matcher"`
 	Hooks   []settingsHookCommand `json:"hooks"`
 }
 

--- a/internal/cli/launch_skill_test.go
+++ b/internal/cli/launch_skill_test.go
@@ -281,6 +281,60 @@ Skill body`
 	}
 }
 
+func TestGenerateClaudeAgentsWithSkills_RefreshesStaleInjectedFile(t *testing.T) {
+	root := t.TempDir()
+	pylonDir := filepath.Join(root, ".pylon")
+	agentsDir := filepath.Join(pylonDir, "agents")
+	claudeAgentsDir := filepath.Join(root, ".claude", "agents")
+	os.MkdirAll(agentsDir, 0755)
+	os.MkdirAll(claudeAgentsDir, 0755)
+
+	agentContent := `---
+name: test-agent
+role: Test Agent
+skills:
+  - some-skill
+---
+# Test Agent`
+	os.WriteFile(filepath.Join(agentsDir, "test-agent.md"), []byte(agentContent), 0644)
+
+	// New skill body (as if updated by a version upgrade).
+	skillsDir := filepath.Join(pylonDir, "skills")
+	os.MkdirAll(skillsDir, 0755)
+	skillContent := `---
+name: some-skill
+description: A test skill
+---
+NEW skill body content`
+	os.WriteFile(filepath.Join(skillsDir, "some-skill.md"), []byte(skillContent), 0644)
+
+	// Pre-create a regular file carrying the pylon injection marker but STALE
+	// skill content, simulating a file materialized by an older pylon version.
+	staleInjected := "# Test Agent\n\n## 주입된 스킬\n\n### some-skill\n_A test skill_\n\nOLD stale skill body\n"
+	linkPath := filepath.Join(claudeAgentsDir, "test-agent.md")
+	os.WriteFile(linkPath, []byte(staleInjected), 0644)
+
+	cfg := &config.Config{
+		Skills: config.SkillsConfig{
+			Enabled:               true,
+			PreloadToAgents:       true,
+			ProgressiveDisclosure: false,
+		},
+	}
+
+	if err := generateClaudeAgentsWithSkills(root, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, _ := os.ReadFile(linkPath)
+	if strings.Contains(string(content), "OLD stale skill body") {
+		t.Error("stale injected file should be refreshed, but old skill body remains")
+	}
+	if !strings.Contains(string(content), "NEW skill body content") {
+		t.Error("refreshed file should contain the new skill body")
+	}
+}
+
 func TestGenerateClaudeAgentsWithSkills_StaleCleanup(t *testing.T) {
 	root := t.TempDir()
 	pylonDir := filepath.Join(root, ".pylon")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -122,9 +122,10 @@ Examples:
 
 			fmt.Printf("✅ pylon %s 설치 완료\n", release.TagName)
 
-			// Run config sync using the NEW binary
+			// Run config sync using the NEW binary, preserving any --workspace override
+			// so resource sync targets the same workspace the user is updating.
 			fmt.Println("\n설정 동기화 중...")
-			doctorCmd := exec.Command(currentBinary, "doctor")
+			doctorCmd := exec.Command(currentBinary, doctorSyncArgs(flagWorkspace)...)
 			doctorCmd.Stdout = os.Stdout
 			doctorCmd.Stderr = os.Stderr
 			if err := doctorCmd.Run(); err != nil {
@@ -134,6 +135,16 @@ Examples:
 			return nil
 		},
 	}
+}
+
+// doctorSyncArgs builds the argument list for the post-update `pylon doctor`
+// invocation, propagating the --workspace override when one is set.
+func doctorSyncArgs(workspace string) []string {
+	args := []string{"doctor"}
+	if workspace != "" {
+		args = append(args, "--workspace", workspace)
+	}
+	return args
 }
 
 // resolveUpdateTarget determines the version target from CLI args.

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -71,6 +72,26 @@ func TestResolveUpdateTarget(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("resolveUpdateTarget(%v) = %q, want %q", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDoctorSyncArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		workspace string
+		want      []string
+	}{
+		{"no workspace override", "", []string{"doctor"}},
+		{"workspace override propagated", "/tmp/ws", []string{"doctor", "--workspace", "/tmp/ws"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := doctorSyncArgs(tt.workspace)
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Errorf("doctorSyncArgs(%q) = %v, want %v", tt.workspace, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## 배경

기존 사용자가 pylon을 버전업해도 내장 skill/command/agent/script가 새 버전 내용으로 갱신되지 않는 문제가 있었습니다. 원인은 `pylon update` → `doctor`의 `syncEmbeddedDir`이 **이미 존재하는 파일을 무조건 스킵**한 것입니다.

## 변경 사항

1. **`doctor.go` `syncEmbeddedDir`** — 기존 파일을 무조건 스킵하던 것을, 내장 내용과 디스크 내용이 **다를 때만 갱신**하도록 변경. (`.pylon/agents·skills·commands·scripts`)
2. **`update.go`** — `doctor` 호출 시 `--workspace` 플래그를 전달해 지정/외부 경로에서도 올바른 워크스페이스를 동기화.
3. **`launch.go` `generateClaudeAgentsWithSkills`** — 스킬이 주입된 `.claude/agents/*.md`를 **주입 마커(`## 주입된 스킬`) 기반**으로 갱신.

## 안전성 — 사용자 콘텐츠 보존

덮어쓰는 대상은 **pylon이 만든 pl 리소스로 한정**되며, 사용자가 직접 작성한 Claude 콘텐츠는 보존됩니다.

- `syncEmbeddedDir`은 pylon 임베디드 이름 파일만 순회 → 사용자가 추가한 자기 파일은 건드리지 않음
- `.claude/agents/`는 **주입 마커가 있는 pylon 생성 파일만** 갱신, 마커 없는 사용자 작성 파일은 보존 (`TestGenerateClaudeAgentsWithSkills_UserFileProtected`로 보장)
- `.claude/commands/pl/` 네임스페이스로 한정 → 사용자 본인 커맨드와 분리
- 모든 쓰기 대상은 워크스페이스 `.pylon/`·`.claude/` (글로벌 `~/.claude/` 미접촉)

## 동작

`pylon update` 직후: `.pylon/*`와 `.claude/agents/*`(skill/agent)는 즉시 반영. `/pl:*` 커맨드는 다음 `pylon launch`에서 갱신(`.claude/commands/pl/`은 launch가 재생성).

## 테스트

- 신규: `TestSyncEmbeddedDir_RefreshesStaleFile`, `TestSyncEmbeddedDir_SkipsUnchangedFile`, `TestDoctorSyncArgs`, `TestGenerateClaudeAgentsWithSkills_RefreshesStaleInjectedFile`
- 기존 `TestGenerateClaudeAgentsWithSkills_UserFileProtected` 유지(사용자 파일 보존 검증)
- 전체 모듈 테스트·build·vet·gofmt 통과

## 참고

전체 스위트에서 가끔 실패하는 `TestBuildIncrementalKey_UniqueTimestamp`는 병렬 부하 시 타임스탬프 충돌로 인한 **사전 존재 flaky 테스트**이며 이 변경과 무관합니다.