### PR TITLE
fix: sync-memory raw diff 메모리 오염 수정 및 mem delete/prune 커맨드 추가 (#76)

### DIFF
--- a/internal/cli/hooks.json
+++ b/internal/cli/hooks.json
@@ -1,15 +1,4 @@
 {
-  "PostToolUse": [
-    {
-      "matcher": "Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "pylon sync-memory --incremental --agent claude"
-        }
-      ]
-    }
-  ],
   "Stop": [
     {
       "matcher": "*",

--- a/internal/cli/mem.go
+++ b/internal/cli/mem.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,12 +21,16 @@ func newMemCmd() *cobra.Command {
 사용 가능한 하위 명령:
   search  BM25 검색
   store   메모리 저장
-  list    메모리 목록`,
+  list    메모리 목록
+  delete  메모리 삭제 (키/카테고리 단위)
+  prune   오염 메모리 정리 (카테고리 일괄/중복 제거)`,
 	}
 
 	cmd.AddCommand(newMemSearchCmd())
 	cmd.AddCommand(newMemStoreCmd())
 	cmd.AddCommand(newMemListCmd())
+	cmd.AddCommand(newMemDeleteCmd())
+	cmd.AddCommand(newMemPruneCmd())
 
 	return cmd
 }
@@ -101,6 +106,172 @@ func newMemListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&category, "category", "", "filter by category (optional)")
 
 	return cmd
+}
+
+func newMemDeleteCmd() *cobra.Command {
+	var project, key, category string
+	var dryRun, yes bool
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete memory entries by key or category",
+		Long: `메모리 항목을 삭제합니다.
+
+사용 예:
+  pylon mem delete --project myapp --key some-key
+  pylon mem delete --project myapp --category change --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if project == "" {
+				return fmt.Errorf("--project is required")
+			}
+			if key == "" && category == "" {
+				return fmt.Errorf("--key or --category is required")
+			}
+			return runMemDelete(project, category, key, dryRun, yes)
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "project name")
+	cmd.Flags().StringVar(&key, "key", "", "memory key to delete")
+	cmd.Flags().StringVar(&category, "category", "", "delete all entries in this category")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show affected count without deleting")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+func newMemPruneCmd() *cobra.Command {
+	var project, category string
+	var dedup, dryRun, yes bool
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Prune polluted memory entries (bulk delete / dedup)",
+		Long: `오염된 메모리를 정리합니다. 삭제 후 VACUUM으로 저장 공간을 회수합니다.
+
+사용 예:
+  pylon mem prune --category change                # 전체 프로젝트의 change 일괄 삭제
+  pylon mem prune --category change --project app  # 특정 프로젝트만
+  pylon mem prune --dedup                          # 동일 파일 중복 change 중 최신 1건만 유지
+  pylon mem prune --category change --dry-run      # 영향 건수 미리보기`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !dedup && category == "" {
+				return fmt.Errorf("--category or --dedup is required")
+			}
+			return runMemPrune(project, category, dedup, dryRun, yes)
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "project name (empty = all projects)")
+	cmd.Flags().StringVar(&category, "category", "", "delete all entries in this category")
+	cmd.Flags().BoolVar(&dedup, "dedup", false, "keep only the latest change entry per file")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "show affected count without deleting")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
+
+	return cmd
+}
+
+// confirmDeletion asks the user to confirm a destructive operation.
+func confirmDeletion(count int64) bool {
+	fmt.Printf("%d건이 삭제됩니다. 계속하시겠습니까? [y/N]: ", count)
+	var answer string
+	fmt.Scanln(&answer)
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+func printPruneResult(action string, count int64, dryRun bool) {
+	if flagJSON {
+		data, _ := json.Marshal(map[string]any{
+			"status":  "ok",
+			"action":  action,
+			"count":   count,
+			"dry_run": dryRun,
+		})
+		fmt.Println(string(data))
+	} else if dryRun {
+		fmt.Printf("%d건이 삭제 대상입니다 (dry-run, 실제 삭제되지 않음)\n", count)
+	} else {
+		fmt.Printf("✓ %d건 삭제 완료\n", count)
+	}
+}
+
+func runMemDelete(project, category, key string, dryRun, yes bool) error {
+	_, _, s, err := openWorkspaceStore()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	count, err := s.DeleteMemory(project, category, key, true)
+	if err != nil {
+		return fmt.Errorf("failed to count memory: %w", err)
+	}
+
+	if dryRun || count == 0 {
+		printPruneResult("delete", count, true)
+		return nil
+	}
+
+	if !yes && !flagJSON && !confirmDeletion(count) {
+		fmt.Println("취소되었습니다")
+		return nil
+	}
+
+	deleted, err := s.DeleteMemory(project, category, key, false)
+	if err != nil {
+		return fmt.Errorf("failed to delete memory: %w", err)
+	}
+
+	printPruneResult("delete", deleted, false)
+	return nil
+}
+
+func runMemPrune(project, category string, dedup, dryRun, yes bool) error {
+	_, _, s, err := openWorkspaceStore()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	countFn := func(dry bool) (int64, error) {
+		if dedup {
+			return s.DedupMemoryChanges(project, dry)
+		}
+		return s.DeleteMemory(project, category, "", dry)
+	}
+
+	action := "prune"
+	if dedup {
+		action = "dedup"
+	}
+
+	count, err := countFn(true)
+	if err != nil {
+		return fmt.Errorf("failed to count memory: %w", err)
+	}
+
+	if dryRun || count == 0 {
+		printPruneResult(action, count, true)
+		return nil
+	}
+
+	if !yes && !flagJSON && !confirmDeletion(count) {
+		fmt.Println("취소되었습니다")
+		return nil
+	}
+
+	deleted, err := countFn(false)
+	if err != nil {
+		return fmt.Errorf("failed to prune memory: %w", err)
+	}
+
+	if err := s.Vacuum(); err != nil {
+		return err
+	}
+
+	printPruneResult(action, deleted, false)
+	return nil
 }
 
 func runMemSearch(project, query string, limit int) error {

--- a/internal/cli/sync_memory.go
+++ b/internal/cli/sync_memory.go
@@ -131,22 +131,33 @@ func runSyncIncremental(project, agent, filePath, content string) error {
 	defer s.Close()
 
 	// Read content from stdin if not provided via flag
+	explicitContent := content != ""
 	if content == "" {
 		content = readStdin()
 	}
 
-	// Try to parse Claude Code hook payload from stdin content
-	// PostToolUse hooks receive JSON like:
+	// PostToolUse hooks pipe JSON like:
 	//   {"tool_name": "Write", "tool_input": {"file_path": "...", "content": "..."}, ...}
-	if content != "" {
+	// Storing this raw diff as memory pollutes BM25 search (issue #76), so without
+	// an explicit --content summary we only extract the file path and skip storage.
+	if content != "" && !explicitContent {
 		parsedFile, parsedContent := tryParseToolUsePayload(content)
-		if parsedContent != "" {
-			content = parsedContent
-		}
 		if parsedFile != "" && filePath == "" {
 			filePath = parsedFile
 		}
+		if parsedFile != "" || parsedContent != "" {
+			if flagJSON {
+				fmt.Println(`{"status":"skip","reason":"raw tool payload without --content"}`)
+			} else {
+				fmt.Println("요약(--content) 없이 전달된 raw 도구 페이로드는 저장하지 않습니다")
+			}
+			return nil
+		}
 	}
+
+	// Normalize worktree paths so the same file edited in a worktree and in the
+	// main checkout resolves to one project/key instead of duplicating entries.
+	filePath = normalizeWorktreePath(filePath)
 
 	// Resolve project name using file path for multi-project inference
 	project, err = resolveProject(root, project, filePath)
@@ -386,6 +397,26 @@ func tryParseToolUsePayload(data string) (filePath, content string) {
 	}
 
 	return filePath, content
+}
+
+// normalizeWorktreePath removes a `.claude/worktrees/<name>/` segment from a
+// path so worktree copies of a file map to the same project and memory key.
+func normalizeWorktreePath(p string) string {
+	if p == "" {
+		return p
+	}
+	const marker = ".claude/worktrees/"
+	sl := filepath.ToSlash(p)
+	idx := strings.Index(sl, marker)
+	if idx < 0 {
+		return p
+	}
+	rest := sl[idx+len(marker):]
+	sep := strings.Index(rest, "/")
+	if sep < 0 {
+		return p
+	}
+	return filepath.FromSlash(sl[:idx] + rest[sep+1:])
 }
 
 // buildIncrementalKey creates a memory key for incremental file change tracking.

--- a/internal/cli/sync_memory_test.go
+++ b/internal/cli/sync_memory_test.go
@@ -529,38 +529,10 @@ func TestGenerateSettingsHooks(t *testing.T) {
 		t.Errorf("Stop hook command should contain 'pylon sync-memory --from-session', got: %s", cmd)
 	}
 
-	// Verify PostToolUse hook exists with correct structure
-	postHooks, ok := hooksMap["PostToolUse"]
-	if !ok {
-		t.Fatal("PostToolUse hook not found")
-	}
-	postArr, ok := postHooks.([]any)
-	if !ok || len(postArr) == 0 {
-		t.Fatal("PostToolUse hook should be a non-empty array")
-	}
-	postGroup, ok := postArr[0].(map[string]any)
-	if !ok {
-		t.Fatal("PostToolUse hook group should be a map")
-	}
-	// Verify matcher is a string
-	postMatcher, ok := postGroup["matcher"].(string)
-	if !ok {
-		t.Fatal("PostToolUse hook matcher should be a string")
-	}
-	if postMatcher != "Edit|Write" {
-		t.Errorf("PostToolUse hook matcher = %q, want 'Edit|Write'", postMatcher)
-	}
-	// Verify hooks array
-	postInnerHooks, ok := postGroup["hooks"].([]any)
-	if !ok || len(postInnerHooks) == 0 {
-		t.Fatal("PostToolUse hook group should have a non-empty 'hooks' array")
-	}
-	postCmd, ok := postInnerHooks[0].(map[string]any)
-	if !ok {
-		t.Fatal("PostToolUse inner hook should be a map")
-	}
-	if postCmd["type"] != "command" {
-		t.Errorf("PostToolUse hook type = %v, want 'command'", postCmd["type"])
+	// PostToolUse hook must NOT be installed by default: it stored raw edit
+	// diffs as memory and polluted BM25 search (issue #76).
+	if _, ok := hooksMap["PostToolUse"]; ok {
+		t.Fatal("PostToolUse hook should not be installed by default (issue #76)")
 	}
 
 	// Verify no description field (not in Claude Code spec)
@@ -886,5 +858,60 @@ func TestGenerateClaudeDir_IncludesSettings(t *testing.T) {
 	hooksMap, ok := hooks.(map[string]any)
 	if !ok || len(hooksMap) == 0 {
 		t.Error("settings.json hooks should contain hook definitions")
+	}
+}
+
+func TestNormalizeWorktreePath(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"src/main.go", "src/main.go"},
+		{".claude/worktrees/task+123/src/main.go", "src/main.go"},
+		{"/Users/me/ws/.claude/worktrees/fix-bug/internal/a.go", "/Users/me/ws/internal/a.go"},
+		{".claude/worktrees/only-name", ".claude/worktrees/only-name"},
+	}
+	for _, tt := range tests {
+		if got := normalizeWorktreePath(tt.input); got != tt.want {
+			t.Errorf("normalizeWorktreePath(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// stdin에서 raw 도구 페이로드가 들어오고 --content가 없으면 저장을 건너뛰어야 한다 (issue #76).
+func TestRunSyncIncremental_SkipsRawToolPayload(t *testing.T) {
+	tmpDir := setupTestWorkspace(t)
+
+	oldWorkspace := flagWorkspace
+	flagWorkspace = tmpDir
+	defer func() { flagWorkspace = oldWorkspace }()
+
+	payload := `{"tool_name": "Edit", "tool_input": {"file_path": "src/main.go", "old_string": "a", "new_string": "b"}}`
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.WriteString(payload)
+	w.Close()
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = oldStdin }()
+
+	if err := runSyncIncremental("test-project", "test-agent", "", ""); err != nil {
+		t.Fatalf("runSyncIncremental() error = %v", err)
+	}
+
+	_, _, s, err := openWorkspaceStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	entries, err := s.ListProjectMemory("test-project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("raw tool payload should not be stored, got %d entries", len(entries))
 	}
 }

--- a/internal/store/project_memory.go
+++ b/internal/store/project_memory.go
@@ -216,6 +216,96 @@ func (s *Store) ListProjectMemory(projectID string) ([]MemoryEntry, error) {
 	return entries, rows.Err()
 }
 
+// keyFilePrefixExpr extracts the file portion of an incremental key
+// ("<file>/<timestamp>"); keys without '/' are used as-is.
+const keyFilePrefixExpr = `CASE WHEN instr(%s.key, '/') > 0 THEN substr(%s.key, 1, instr(%s.key, '/') - 1) ELSE %s.key END`
+
+// DeleteMemory removes memory entries matching the given filters.
+// projectID가 빈 문자열이면 전체 프로젝트를 대상으로 한다. key와 category는
+// 비어 있지 않은 것만 조건에 포함된다. dryRun이면 삭제하지 않고 건수만 반환한다.
+// FTS 인덱스는 delete 트리거로 자동 동기화된다.
+func (s *Store) DeleteMemory(projectID, category, key string, dryRun bool) (int64, error) {
+	var conds []string
+	var args []any
+	if projectID != "" {
+		conds = append(conds, "project_id = ?")
+		args = append(args, projectID)
+	}
+	if category != "" {
+		conds = append(conds, "category = ?")
+		args = append(args, category)
+	}
+	if key != "" {
+		conds = append(conds, "key = ?")
+		args = append(args, key)
+	}
+	if len(conds) == 0 {
+		return 0, fmt.Errorf("at least one filter (project, category, key) is required")
+	}
+	where := strings.Join(conds, " AND ")
+
+	if dryRun {
+		var n int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM project_memory WHERE `+where, args...).Scan(&n)
+		if err != nil {
+			return 0, fmt.Errorf("failed to count memory: %w", err)
+		}
+		return n, nil
+	}
+
+	res, err := s.db.Exec(`DELETE FROM project_memory WHERE `+where, args...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete memory: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// DedupMemoryChanges removes duplicate "change" entries for the same file,
+// keeping only the most recent one per (project, file). projectID가 빈 문자열이면
+// 전체 프로젝트를 대상으로 한다.
+func (s *Store) DedupMemoryChanges(projectID string, dryRun bool) (int64, error) {
+	pmPrefix := fmt.Sprintf(keyFilePrefixExpr, "pm", "pm", "pm", "pm")
+	p2Prefix := fmt.Sprintf(keyFilePrefixExpr, "p2", "p2", "p2", "p2")
+
+	where := fmt.Sprintf(`
+		pm.category = 'change'
+		AND (? = '' OR pm.project_id = ?)
+		AND EXISTS (
+			SELECT 1 FROM project_memory p2
+			WHERE p2.project_id = pm.project_id
+			  AND p2.category = pm.category
+			  AND %s = %s
+			  AND (p2.created_at > pm.created_at
+			       OR (p2.created_at = pm.created_at AND p2.id > pm.id))
+		)`, p2Prefix, pmPrefix)
+
+	args := []any{projectID, projectID}
+
+	if dryRun {
+		var n int64
+		err := s.db.QueryRow(`SELECT COUNT(*) FROM project_memory pm WHERE `+where, args...).Scan(&n)
+		if err != nil {
+			return 0, fmt.Errorf("failed to count duplicate memory: %w", err)
+		}
+		return n, nil
+	}
+
+	res, err := s.db.Exec(`DELETE FROM project_memory WHERE id IN (
+		SELECT pm.id FROM project_memory pm WHERE `+where+`)`, args...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to dedup memory: %w", err)
+	}
+	return res.RowsAffected()
+}
+
+// Vacuum reclaims unused space in the database file.
+func (s *Store) Vacuum() error {
+	if _, err := s.db.Exec(`VACUUM`); err != nil {
+		return fmt.Errorf("failed to vacuum database: %w", err)
+	}
+	return nil
+}
+
 // IncrementAccessCount bumps the access count for a memory entry.
 func (s *Store) IncrementAccessCount(memoryID string) error {
 	_, err := s.db.Exec(`UPDATE project_memory SET access_count = access_count + 1 WHERE id = ?`, memoryID)

--- a/internal/store/project_memory_test.go
+++ b/internal/store/project_memory_test.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func insertChange(t *testing.T, s *Store, project, key, content string, createdAt time.Time) {
+	t.Helper()
+	entry := &MemoryEntry{
+		ProjectID: project,
+		Category:  "change",
+		Key:       key,
+		Content:   content,
+	}
+	if err := s.InsertMemory(entry); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`UPDATE project_memory SET created_at = ? WHERE id = ?`, createdAt, entry.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteMemory_ByKey(t *testing.T) {
+	s := setupTestStore(t)
+
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "general", Key: "keep", Content: "keep me"})
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "general", Key: "gone", Content: "delete me"})
+
+	n, err := s.DeleteMemory("p1", "", "gone", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted = %d, want 1", n)
+	}
+
+	entries, _ := s.ListProjectMemory("p1")
+	if len(entries) != 1 || entries[0].Key != "keep" {
+		t.Fatalf("unexpected remaining entries: %+v", entries)
+	}
+}
+
+func TestDeleteMemory_ByCategory_DryRun(t *testing.T) {
+	s := setupTestStore(t)
+
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "change", Key: "a/1", Content: "diff1"})
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "change", Key: "b/1", Content: "diff2"})
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "general", Key: "g", Content: "knowledge"})
+
+	n, err := s.DeleteMemory("p1", "change", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("dry-run count = %d, want 2", n)
+	}
+	entries, _ := s.ListProjectMemory("p1")
+	if len(entries) != 3 {
+		t.Fatalf("dry-run must not delete, got %d entries", len(entries))
+	}
+
+	n, err = s.DeleteMemory("p1", "change", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("deleted = %d, want 2", n)
+	}
+	entries, _ = s.ListProjectMemory("p1")
+	if len(entries) != 1 || entries[0].Category != "general" {
+		t.Fatalf("unexpected remaining entries: %+v", entries)
+	}
+}
+
+func TestDeleteMemory_RequiresFilter(t *testing.T) {
+	s := setupTestStore(t)
+	if _, err := s.DeleteMemory("", "", "", false); err == nil {
+		t.Fatal("expected error when no filter is given")
+	}
+}
+
+func TestDeleteMemory_SyncsFTS(t *testing.T) {
+	s := setupTestStore(t)
+
+	s.InsertMemory(&MemoryEntry{ProjectID: "p1", Category: "change", Key: "k", Content: "uniqueword"})
+	if _, err := s.DeleteMemory("p1", "change", "", false); err != nil {
+		t.Fatal(err)
+	}
+	results, err := s.SearchMemory("p1", "uniqueword", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("FTS index should be synced after delete, got %d results", len(results))
+	}
+}
+
+func TestDedupMemoryChanges(t *testing.T) {
+	s := setupTestStore(t)
+	base := time.Now().Add(-time.Hour)
+
+	// Same file edited three times, plus a distinct file and another project.
+	insertChange(t, s, "p1", "src-main-go/1", "old edit 1", base)
+	insertChange(t, s, "p1", "src-main-go/2", "old edit 2", base.Add(time.Minute))
+	insertChange(t, s, "p1", "src-main-go/3", "latest edit", base.Add(2*time.Minute))
+	insertChange(t, s, "p1", "other-file/1", "other", base)
+	insertChange(t, s, "p2", "src-main-go/1", "p2 edit", base)
+
+	n, err := s.DedupMemoryChanges("p1", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("dry-run dedup count = %d, want 2", n)
+	}
+
+	n, err = s.DedupMemoryChanges("p1", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("dedup deleted = %d, want 2", n)
+	}
+
+	entries, _ := s.GetMemoryByCategory("p1", "change")
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries after dedup, got %d", len(entries))
+	}
+	for _, e := range entries {
+		if e.Key == "src-main-go/1" || e.Key == "src-main-go/2" {
+			t.Fatalf("older duplicate %q should have been removed", e.Key)
+		}
+	}
+
+	// Other project must be untouched.
+	p2, _ := s.GetMemoryByCategory("p2", "change")
+	if len(p2) != 1 {
+		t.Fatalf("p2 entries should be untouched, got %d", len(p2))
+	}
+}
+
+func TestDedupMemoryChanges_AllProjects(t *testing.T) {
+	s := setupTestStore(t)
+	base := time.Now().Add(-time.Hour)
+
+	insertChange(t, s, "p1", "f/1", "old", base)
+	insertChange(t, s, "p1", "f/2", "new", base.Add(time.Minute))
+	insertChange(t, s, "p2", "f/1", "old", base)
+	insertChange(t, s, "p2", "f/2", "new", base.Add(time.Minute))
+
+	n, err := s.DedupMemoryChanges("", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("deleted = %d, want 2", n)
+	}
+}
+
+func TestVacuum(t *testing.T) {
+	s := setupTestStore(t)
+	if err := s.Vacuum(); err != nil {
+		t.Fatalf("Vacuum() error = %v", err)
+	}
+}


### PR DESCRIPTION
Closes #76

## 배경

`PostToolUse` 훅으로 자동 호출되던 `pylon sync-memory --incremental`이 파일 편집 1회마다 raw diff를 `change` 카테고리로 저장해, 프로젝트 메모리가 편집 로그로 오염되고 BM25 검색이 무력화되는 문제. 또한 오염을 치울 삭제 수단(`pylon mem delete/prune`)이 부재했음.

## 변경 사항

### 오염 원인 차단
- `sync-memory --incremental`: `--content` 없이 stdin으로 raw 도구 페이로드(Edit/Write JSON)가 들어오면 저장하지 않고 skip. 명시적 요약이 있을 때만 저장.
- `normalizeWorktreePath`: 파일 경로의 `.claude/worktrees/<name>/` 세그먼트를 제거해 워크트리 편집이 별도 프로젝트/키로 갈라지지 않도록 정규화.
- 기본 훅(`hooks.json`)에서 `PostToolUse Edit|Write` 항목 제거. `Stop`의 `--from-session` 요약 저장만 기본 유지. (기존 설치본은 `mergeHooks`가 다음 launch 시 자동 교체)

### 정리 수단 추가
- `pylon mem delete --project <p> --key <k> | --category <c>` — 단건·카테고리 삭제
- `pylon mem prune --category change [--project <p>]` — 오염 카테고리 일괄 정리
- `pylon mem prune --dedup` — 동일 파일 중복 change 중 최신 1건만 유지
- 공통 `--dry-run`(영향 건수 미리보기), 미확인 시 확인 프롬프트(`--yes`로 skip), prune 후 VACUUM 수행. FTS 인덱스는 기존 delete 트리거로 동기화.

## 테스트
- store 계층: 삭제/드라이런/FTS 동기화/dedup/전체 프로젝트 dedup 테스트 추가
- CLI: raw 페이로드 skip, 워크트리 경로 정규화 테스트 추가
- `go vet` 및 전체 테스트 통과, 빌드 바이너리로 스모크 테스트 확인