### PR TITLE
fix: buildIncrementalKey 키 충돌 및 flaky 테스트 수정

### DIFF
--- a/internal/cli/sync_memory.go
+++ b/internal/cli/sync_memory.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -419,10 +420,17 @@ func normalizeWorktreePath(p string) string {
 	return filepath.FromSlash(sl[:idx] + rest[sep+1:])
 }
 
+// incrementalKeySeq is a process-local monotonic counter appended to
+// incremental keys so they stay unique even when multiple calls fall within the
+// same clock tick. time.Now() resolution is platform-dependent and can repeat
+// in rapid succession, which would otherwise collide the UNIQUE(project_id,
+// category, key) memory constraint.
+var incrementalKeySeq atomic.Uint64
+
 // buildIncrementalKey creates a memory key for incremental file change tracking.
 // The key does not include the category prefix since that is stored separately.
 func buildIncrementalKey(filePath string) string {
-	ts := time.Now().Format("20060102-150405.000000000")
+	ts := fmt.Sprintf("%s-%d", time.Now().Format("20060102-150405.000000000"), incrementalKeySeq.Add(1))
 	if filePath != "" {
 		// Use file path as part of key for traceability
 		// Normalize both forward and back slashes for cross-platform compatibility

--- a/internal/cli/sync_memory_test.go
+++ b/internal/cli/sync_memory_test.go
@@ -365,11 +365,17 @@ func TestBuildIncrementalKey_LongPath(t *testing.T) {
 }
 
 func TestBuildIncrementalKey_UniqueTimestamp(t *testing.T) {
-	// Two keys generated in quick succession should be different due to nanoseconds
-	key1 := buildIncrementalKey("test.go")
-	key2 := buildIncrementalKey("test.go")
-	if key1 == key2 {
-		t.Errorf("keys should be unique even in rapid succession: %q == %q", key1, key2)
+	// Keys generated in rapid succession must all be unique. The timestamp alone
+	// is not sufficient because time.Now() resolution can repeat within a tick;
+	// a monotonic sequence guarantees uniqueness (see buildIncrementalKey).
+	const n = 1000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		k := buildIncrementalKey("test.go")
+		if _, dup := seen[k]; dup {
+			t.Fatalf("duplicate key generated in rapid succession: %q", k)
+		}
+		seen[k] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
## 문제

`buildIncrementalKey`가 나노초 타임스탬프에만 의존해 키를 생성한다. `time.Now()` 해상도는 플랫폼에 따라 같은 틱을 반복 반환할 수 있어:

1. **잠재 버그**: 같은 나노초에 기록된 두 증분 변경의 메모리 키가 충돌하면 `UNIQUE(project_id, category, key)` 제약을 위반한다.
2. **flaky 테스트**: `TestBuildIncrementalKey_UniqueTimestamp`가 두 키의 동일 여부에 의존해 간헐적으로 실패했다(`internal/cli` 패키지 전체 실행 시 재현).

## 수정

타임스탬프 뒤에 프로세스 로컬 원자 카운터(`atomic.Uint64`)를 붙여 유일성을 보장한다. 키 포맷은 `<clean>/<ts>-<seq>`로, 기존 테스트가 의존하는 제약(`.` 포함, 세그먼트 2개, 타임스탬프 접두어)을 그대로 유지한다.

flaky 테스트는 근본 원인이 해소되며, 1000회 반복 유일성 검증으로 강화했다.

## 검증

- `go build ./...`, `go vet` 통과
- `go test ./internal/cli/ -run TestBuildIncrementalKey -race -count=20` 통과
- `internal/cli` 패키지 전체 5회 연속 통과(이전엔 간헐 실패)
- 전체 스위트 통과