### PR TITLE
feat: doctor 실행 시 Claude Code 슬래시 커맨드 동기화

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"embed"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kyago/pylon/internal/config"
@@ -55,6 +58,7 @@ for any projects that are missing the local-scope ignore entry.`,
 	}
 
 	cmd.Flags().Bool("fix-excludes", false, "auto-fix missing .pylon/ exclude entries in project repos")
+	cmd.Flags().Bool("yes", false, "커맨드 동기화 확인 프롬프트를 건너뛰고 자동 승인")
 
 	return cmd
 }
@@ -91,6 +95,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	// Sync embedded resources (agents, skills, commands, scripts) if in a workspace
 	syncResourcesIfWorkspace()
+
+	// Reconcile Claude Code slash commands (.claude/commands/) with confirmation.
+	// Runs after .pylon/commands/ is synced so the diff reflects the latest content.
+	autoYes, _ := cmd.Flags().GetBool("yes")
+	syncClaudeCommandsIfWorkspace(cmd.InOrStdin(), autoYes)
 
 	// Check project repo .pylon/ exclude settings (skip if git is missing)
 	fixExcludes, _ := cmd.Flags().GetBool("fix-excludes")
@@ -379,6 +388,95 @@ func syncEmbeddedDir(fs embed.FS, embedDir, targetDir, suffix string) int {
 		written++
 	}
 	return written
+}
+
+// commandDiff describes how the on-disk .claude/commands/ differs from the
+// desired command set.
+type commandDiff struct {
+	added   []string // in desired, missing on disk
+	changed []string // present but content differs
+	removed []string // legacy files present on disk that will be deleted
+}
+
+func (d commandDiff) empty() bool {
+	return len(d.added) == 0 && len(d.changed) == 0 && len(d.removed) == 0
+}
+
+// diffClaudeCommands compares the desired command set against the on-disk
+// .claude/commands/. Removals are limited to the fixed legacy list, mirroring
+// applyClaudeCommands — user-added commands are never flagged for deletion.
+func diffClaudeCommands(commandsDir string, desired map[string]string) commandDiff {
+	var d commandDiff
+	for rel, content := range desired {
+		existing, err := os.ReadFile(filepath.Join(commandsDir, rel))
+		if err != nil {
+			d.added = append(d.added, rel)
+		} else if !bytes.Equal(existing, []byte(content)) {
+			d.changed = append(d.changed, rel)
+		}
+	}
+	for _, name := range legacyCommandFiles {
+		if _, err := os.Stat(filepath.Join(commandsDir, name+".md")); err == nil {
+			d.removed = append(d.removed, name+".md")
+		}
+	}
+	sort.Strings(d.added)
+	sort.Strings(d.changed)
+	sort.Strings(d.removed)
+	return d
+}
+
+// syncClaudeCommandsIfWorkspace reconciles .claude/commands/ with the desired
+// command set when inside a pylon workspace. It prints a diff and only applies
+// changes after the user consents (default: No). When autoYes is true the prompt
+// is skipped and changes are applied automatically.
+func syncClaudeCommandsIfWorkspace(in io.Reader, autoYes bool) {
+	startDir := flagWorkspace
+	if startDir == "" {
+		startDir = "."
+	}
+	root, err := config.FindWorkspaceRoot(startDir)
+	if err != nil {
+		return // not in a workspace, skip
+	}
+
+	commandsDir := filepath.Join(root, ".claude", "commands")
+	desired := buildDesiredClaudeCommands(root)
+	diff := diffClaudeCommands(commandsDir, desired)
+
+	fmt.Println()
+	if diff.empty() {
+		fmt.Println("✓ Claude Code 커맨드 최신 상태")
+		return
+	}
+
+	fmt.Println("🔄 Claude Code 커맨드 변경 사항:")
+	for _, f := range diff.added {
+		fmt.Printf("  + %s (추가)\n", f)
+	}
+	for _, f := range diff.changed {
+		fmt.Printf("  ~ %s (변경)\n", f)
+	}
+	for _, f := range diff.removed {
+		fmt.Printf("  - %s (삭제)\n", f)
+	}
+
+	if !autoYes {
+		fmt.Print("적용하시겠습니까? [y/N]: ")
+		answer, _ := bufio.NewReader(in).ReadString('\n')
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Println("커맨드 동기화 건너뜀")
+			return
+		}
+	}
+
+	if err := applyClaudeCommands(commandsDir, desired); err != nil {
+		fmt.Printf("⚠ 커맨드 동기화 실패: %v\n", err)
+		return
+	}
+	total := len(diff.added) + len(diff.changed) + len(diff.removed)
+	fmt.Printf("✓ 커맨드 %d개 동기화 완료\n", total)
 }
 
 func verifyClaude() (string, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -420,6 +420,22 @@ func diffClaudeCommands(commandsDir string, desired map[string]string) commandDi
 			d.removed = append(d.removed, name+".md")
 		}
 	}
+	removed := make(map[string]bool)
+	for _, rel := range d.removed {
+		removed[rel] = true
+	}
+	for rel := range readManagedClaudeCommandSet(commandsDir) {
+		if _, ok := desired[rel]; ok {
+			continue
+		}
+		if removed[rel] {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(commandsDir, rel)); err == nil {
+			d.removed = append(d.removed, rel)
+			removed[rel] = true
+		}
+	}
 	sort.Strings(d.added)
 	sort.Strings(d.changed)
 	sort.Strings(d.removed)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -344,6 +344,156 @@ func TestCheckRepoExcludes_SkipsNonGitProjects(t *testing.T) {
 	}
 }
 
+// newTestWorkspace creates a minimal pylon workspace (empty .pylon/commands/)
+// and points flagWorkspace at it for the duration of the test.
+func newTestWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".pylon", "commands"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pylon", "config.yml"), []byte("version: \"0.1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	old := flagWorkspace
+	flagWorkspace = root
+	t.Cleanup(func() { flagWorkspace = old })
+	return root
+}
+
+// TestBuildDesiredClaudeCommands_Keyset verifies the desired command set equals
+// exactly the dynamic slash commands plus the embedded pl-* commands (prefix
+// stripped). This guards the shared source of truth used by launch and doctor.
+func TestBuildDesiredClaudeCommands_Keyset(t *testing.T) {
+	root := newTestWorkspace(t) // empty .pylon/commands -> embedded fallback
+
+	desired := buildDesiredClaudeCommands(root)
+
+	want := map[string]bool{
+		filepath.Join("pl", "index.md"):        true,
+		filepath.Join("pl", "project-list.md"): true,
+	}
+	embedded, err := embeddedCommands.ReadDir("commands")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range embedded {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		want[filepath.Join("pl", strings.TrimPrefix(e.Name(), "pl-"))] = true
+	}
+
+	if len(desired) != len(want) {
+		t.Errorf("desired has %d files, want %d", len(desired), len(want))
+	}
+	for k := range want {
+		if _, ok := desired[k]; !ok {
+			t.Errorf("desired missing expected key %q", k)
+		}
+	}
+	for k := range desired {
+		if !want[k] {
+			t.Errorf("desired has unexpected key %q", k)
+		}
+	}
+}
+
+func TestDiffClaudeCommands(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+	desired := buildDesiredClaudeCommands(root)
+
+	// Nothing on disk -> everything is an addition, nothing changed/removed.
+	diff := diffClaudeCommands(commandsDir, desired)
+	if len(diff.added) != len(desired) {
+		t.Errorf("added = %d, want %d", len(diff.added), len(desired))
+	}
+	if len(diff.changed) != 0 || len(diff.removed) != 0 {
+		t.Errorf("expected no changed/removed, got changed=%d removed=%d", len(diff.changed), len(diff.removed))
+	}
+
+	// Apply, then a stale edit + a legacy file -> one changed + one removed.
+	if err := applyClaudeCommands(commandsDir, desired); err != nil {
+		t.Fatal(err)
+	}
+	staleTarget := filepath.Join("pl", "index.md")
+	if err := os.WriteFile(filepath.Join(commandsDir, staleTarget), []byte("STALE\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commandsDir, "status.md"), []byte("legacy\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	diff = diffClaudeCommands(commandsDir, desired)
+	if len(diff.added) != 0 {
+		t.Errorf("expected no additions, got %v", diff.added)
+	}
+	if len(diff.changed) != 1 || diff.changed[0] != staleTarget {
+		t.Errorf("changed = %v, want [%s]", diff.changed, staleTarget)
+	}
+	if len(diff.removed) != 1 || diff.removed[0] != "status.md" {
+		t.Errorf("removed = %v, want [status.md]", diff.removed)
+	}
+}
+
+func TestSyncClaudeCommands_ConsentApplies(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+
+	syncClaudeCommandsIfWorkspace(bytes.NewBufferString("y\n"), false)
+
+	if _, err := os.Stat(filepath.Join(commandsDir, "pl", "index.md")); err != nil {
+		t.Errorf("expected pl/index.md to be created after consent: %v", err)
+	}
+}
+
+func TestSyncClaudeCommands_DeclineDoesNothing(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+
+	syncClaudeCommandsIfWorkspace(bytes.NewBufferString("n\n"), false)
+
+	if _, err := os.Stat(filepath.Join(commandsDir, "pl", "index.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no commands written after decline, got err=%v", err)
+	}
+}
+
+// TestSyncClaudeCommands_EmptyInputDeclines verifies default = No on EOF.
+func TestSyncClaudeCommands_EmptyInputDeclines(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+
+	syncClaudeCommandsIfWorkspace(bytes.NewBufferString(""), false)
+
+	if _, err := os.Stat(filepath.Join(commandsDir, "pl", "index.md")); !os.IsNotExist(err) {
+		t.Errorf("expected no commands written on empty input, got err=%v", err)
+	}
+}
+
+// TestSyncClaudeCommands_AutoYesSkipsPrompt applies without reading stdin.
+func TestSyncClaudeCommands_AutoYesSkipsPrompt(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+
+	syncClaudeCommandsIfWorkspace(bytes.NewBufferString(""), true)
+
+	if _, err := os.Stat(filepath.Join(commandsDir, "pl", "index.md")); err != nil {
+		t.Errorf("expected commands written with autoYes, got err=%v", err)
+	}
+}
+
+func TestNewDoctorCmd_YesFlag(t *testing.T) {
+	cmd := newDoctorCmd()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("--yes flag not found")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--yes default = %q, want %q", f.DefValue, "false")
+	}
+}
+
 func TestNewDoctorCmd_FixExcludesFlag(t *testing.T) {
 	cmd := newDoctorCmd()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -437,6 +437,39 @@ func TestDiffClaudeCommands(t *testing.T) {
 	}
 }
 
+func TestDiffClaudeCommands_RemovesPreviouslyManagedCommand(t *testing.T) {
+	root := newTestWorkspace(t)
+	commandsDir := filepath.Join(root, ".claude", "commands")
+	initial := map[string]string{
+		filepath.Join("pl", "old.md"):  "old\n",
+		filepath.Join("pl", "keep.md"): "keep\n",
+	}
+	if err := applyClaudeCommands(commandsDir, initial); err != nil {
+		t.Fatal(err)
+	}
+	custom := filepath.Join(commandsDir, "pl", "custom.md")
+	if err := os.WriteFile(custom, []byte("custom\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	desired := map[string]string{
+		filepath.Join("pl", "keep.md"): "keep\n",
+	}
+	diff := diffClaudeCommands(commandsDir, desired)
+	if len(diff.removed) != 1 || diff.removed[0] != filepath.Join("pl", "old.md") {
+		t.Fatalf("removed = %v, want [pl/old.md]", diff.removed)
+	}
+	if err := applyClaudeCommands(commandsDir, desired); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(commandsDir, "pl", "old.md")); !os.IsNotExist(err) {
+		t.Errorf("expected previously managed command to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(custom); err != nil {
+		t.Errorf("expected custom command to be preserved: %v", err)
+	}
+}
+
 func TestSyncClaudeCommands_ConsentApplies(t *testing.T) {
 	root := newTestWorkspace(t)
 	commandsDir := filepath.Join(root, ".claude", "commands")

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -186,75 +186,16 @@ func generateClaudeDir(root string, cfg *config.Config, projects []config.Projec
 		return fmt.Errorf("CLAUDE.md 생성 실패: %w", err)
 	}
 
-	// Clean up legacy command files (pre-namespace) to prevent stale slash commands
-	legacyCommands := []string{"index", "status", "verify", "add-project", "cancel", "review"}
-	for _, name := range legacyCommands {
-		legacy := filepath.Join(commandsDir, name+".md")
-		if err := os.Remove(legacy); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("레거시 커맨드 파일 제거 실패 (%s): %w", legacy, err)
-		}
+	// Reconcile .claude/commands/ with the desired command set. The desired-state
+	// computation is shared with `pylon doctor` so the two never drift.
+	desired := buildDesiredClaudeCommands(root)
+	if err := applyClaudeCommands(commandsDir, desired); err != nil {
+		return err
 	}
 
-	// Generate slash commands from Go code
-	commands := buildSlashCommands(root)
-	for name, content := range commands {
-		cmdPath := filepath.Join(commandsDir, filepath.FromSlash(name)+".md")
-		if err := os.MkdirAll(filepath.Dir(cmdPath), 0755); err != nil {
-			return fmt.Errorf("커맨드 디렉토리 생성 실패: %w", err)
-		}
-		if err := os.WriteFile(cmdPath, []byte(content), 0644); err != nil {
-			return fmt.Errorf("커맨드 %s 생성 실패: %w", name, err)
-		}
-	}
-
-	// Pipeline slash commands → .claude/commands/pl/
-	// Priority: .pylon/commands/ (user customization) > embedded defaults
-	plDir := filepath.Join(commandsDir, "pl")
-	if err := os.MkdirAll(plDir, 0755); err != nil {
-		return fmt.Errorf("pl/ 디렉토리 생성 실패: %w", err)
-	}
-
-	pylonCmdsDir := filepath.Join(root, ".pylon", "commands")
-	if entries, err := os.ReadDir(pylonCmdsDir); err == nil && len(entries) > 0 {
-		// Use workspace .pylon/commands/ (user may have customized)
-		for _, entry := range entries {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-				continue
-			}
-			content, err := os.ReadFile(filepath.Join(pylonCmdsDir, entry.Name()))
-			if err != nil {
-				continue
-			}
-			destName := strings.TrimPrefix(entry.Name(), "pl-")
-			if err := os.WriteFile(filepath.Join(plDir, destName), content, 0644); err != nil {
-				return fmt.Errorf("커맨드 복사 실패 (%s): %w", entry.Name(), err)
-			}
-		}
-	} else {
-		// Fallback: use embedded default commands (existing workspaces without .pylon/commands/)
-		embedded, _ := embeddedCommands.ReadDir("commands")
-		for _, entry := range embedded {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-				continue
-			}
-			content, err := embeddedCommands.ReadFile("commands/" + entry.Name())
-			if err != nil {
-				continue
-			}
-			destName := strings.TrimPrefix(entry.Name(), "pl-")
-			if err := os.WriteFile(filepath.Join(plDir, destName), content, 0644); err != nil {
-				return fmt.Errorf("내장 커맨드 생성 실패 (%s): %w", entry.Name(), err)
-			}
-		}
-		// Also bootstrap .pylon/commands/ for future customization
-		os.MkdirAll(pylonCmdsDir, 0755)
-		for _, entry := range embedded {
-			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
-				continue
-			}
-			content, _ := embeddedCommands.ReadFile("commands/" + entry.Name())
-			_ = os.WriteFile(filepath.Join(pylonCmdsDir, entry.Name()), content, 0644)
-		}
+	// Bootstrap .pylon/commands/ from embedded defaults for future customization
+	if err := bootstrapPylonCommands(filepath.Join(root, ".pylon", "commands")); err != nil {
+		return err
 	}
 
 	// Pipeline scripts → .pylon/scripts/bash/
@@ -557,6 +498,103 @@ func buildSlashCommands(root string) map[string]string {
 `,
 	}
 	return commands
+}
+
+// legacyCommandFiles lists pre-namespace top-level command files that should be
+// removed from .claude/commands/ to prevent stale slash commands.
+var legacyCommandFiles = []string{"index", "status", "verify", "add-project", "cancel", "review"}
+
+// buildDesiredClaudeCommands computes the full set of .claude/commands/ files
+// that should exist, keyed by path relative to the commands dir (e.g.
+// "pl/index.md"). It is read-only and shared by `pylon launch` and `pylon doctor`
+// so both agree on the desired state.
+func buildDesiredClaudeCommands(root string) map[string]string {
+	desired := make(map[string]string)
+
+	// Dynamic slash commands generated from Go code
+	for name, content := range buildSlashCommands(root) {
+		desired[filepath.FromSlash(name)+".md"] = content
+	}
+
+	// Pipeline slash commands → pl/: prefer .pylon/commands/ (user customization),
+	// fall back to embedded defaults for workspaces without .pylon/commands/.
+	pylonCmdsDir := filepath.Join(root, ".pylon", "commands")
+	if entries, err := os.ReadDir(pylonCmdsDir); err == nil && len(entries) > 0 {
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			content, err := os.ReadFile(filepath.Join(pylonCmdsDir, entry.Name()))
+			if err != nil {
+				continue
+			}
+			destName := strings.TrimPrefix(entry.Name(), "pl-")
+			desired[filepath.Join("pl", destName)] = string(content)
+		}
+	} else {
+		embedded, _ := embeddedCommands.ReadDir("commands")
+		for _, entry := range embedded {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			content, err := embeddedCommands.ReadFile("commands/" + entry.Name())
+			if err != nil {
+				continue
+			}
+			destName := strings.TrimPrefix(entry.Name(), "pl-")
+			desired[filepath.Join("pl", destName)] = string(content)
+		}
+	}
+
+	return desired
+}
+
+// applyClaudeCommands writes the desired command files into commandsDir and
+// removes legacy (pre-namespace) top-level command files. It intentionally does
+// NOT remove other on-disk files so any user-added commands are preserved.
+func applyClaudeCommands(commandsDir string, desired map[string]string) error {
+	for _, name := range legacyCommandFiles {
+		legacy := filepath.Join(commandsDir, name+".md")
+		if err := os.Remove(legacy); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("레거시 커맨드 파일 제거 실패 (%s): %w", legacy, err)
+		}
+	}
+	for rel, content := range desired {
+		cmdPath := filepath.Join(commandsDir, rel)
+		if err := os.MkdirAll(filepath.Dir(cmdPath), 0755); err != nil {
+			return fmt.Errorf("커맨드 디렉토리 생성 실패: %w", err)
+		}
+		if err := os.WriteFile(cmdPath, []byte(content), 0644); err != nil {
+			return fmt.Errorf("커맨드 %s 생성 실패: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// bootstrapPylonCommands writes embedded default commands into .pylon/commands/
+// when the directory is empty, giving users a starting point to customize.
+func bootstrapPylonCommands(pylonCmdsDir string) error {
+	if entries, err := os.ReadDir(pylonCmdsDir); err == nil && len(entries) > 0 {
+		return nil // already populated — preserve user customizations
+	}
+	if err := os.MkdirAll(pylonCmdsDir, 0755); err != nil {
+		return fmt.Errorf(".pylon/commands/ 디렉토리 생성 실패: %w", err)
+	}
+	embedded, err := embeddedCommands.ReadDir("commands")
+	if err != nil {
+		return nil
+	}
+	for _, entry := range embedded {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		content, err := embeddedCommands.ReadFile("commands/" + entry.Name())
+		if err != nil {
+			continue
+		}
+		_ = os.WriteFile(filepath.Join(pylonCmdsDir, entry.Name()), content, 0644)
+	}
+	return nil
 }
 
 // addToGitignore appends pylon-managed entries to .gitignore if not already present.

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -504,6 +505,8 @@ func buildSlashCommands(root string) map[string]string {
 // removed from .claude/commands/ to prevent stale slash commands.
 var legacyCommandFiles = []string{"index", "status", "verify", "add-project", "cancel", "review"}
 
+const managedClaudeCommandsManifest = ".pylon-managed.json"
+
 // buildDesiredClaudeCommands computes the full set of .claude/commands/ files
 // that should exist, keyed by path relative to the commands dir (e.g.
 // "pl/index.md"). It is read-only and shared by `pylon launch` and `pylon doctor`
@@ -553,10 +556,20 @@ func buildDesiredClaudeCommands(root string) map[string]string {
 // removes legacy (pre-namespace) top-level command files. It intentionally does
 // NOT remove other on-disk files so any user-added commands are preserved.
 func applyClaudeCommands(commandsDir string, desired map[string]string) error {
+	previouslyManaged := readManagedClaudeCommandSet(commandsDir)
+
 	for _, name := range legacyCommandFiles {
 		legacy := filepath.Join(commandsDir, name+".md")
 		if err := os.Remove(legacy); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("레거시 커맨드 파일 제거 실패 (%s): %w", legacy, err)
+		}
+	}
+	for rel := range previouslyManaged {
+		if _, ok := desired[rel]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(commandsDir, rel)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("이전 커맨드 파일 제거 실패 (%s): %w", rel, err)
 		}
 	}
 	for rel, content := range desired {
@@ -568,7 +581,56 @@ func applyClaudeCommands(commandsDir string, desired map[string]string) error {
 			return fmt.Errorf("커맨드 %s 생성 실패: %w", rel, err)
 		}
 	}
+	if err := writeManagedClaudeCommandSet(commandsDir, desired); err != nil {
+		return err
+	}
 	return nil
+}
+
+func readManagedClaudeCommandSet(commandsDir string) map[string]bool {
+	managed := make(map[string]bool)
+	content, err := os.ReadFile(filepath.Join(commandsDir, managedClaudeCommandsManifest))
+	if err != nil {
+		return managed
+	}
+	var files []string
+	if err := json.Unmarshal(content, &files); err != nil {
+		return managed
+	}
+	for _, rel := range files {
+		if isSafeCommandRel(rel) {
+			managed[rel] = true
+		}
+	}
+	return managed
+}
+
+func writeManagedClaudeCommandSet(commandsDir string, desired map[string]string) error {
+	files := make([]string, 0, len(desired))
+	for rel := range desired {
+		files = append(files, rel)
+	}
+	sort.Strings(files)
+	content, err := json.MarshalIndent(files, "", "  ")
+	if err != nil {
+		return fmt.Errorf("커맨드 매니페스트 생성 실패: %w", err)
+	}
+	content = append(content, '\n')
+	if err := os.MkdirAll(commandsDir, 0755); err != nil {
+		return fmt.Errorf("커맨드 디렉토리 생성 실패: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(commandsDir, managedClaudeCommandsManifest), content, 0644); err != nil {
+		return fmt.Errorf("커맨드 매니페스트 쓰기 실패: %w", err)
+	}
+	return nil
+}
+
+func isSafeCommandRel(rel string) bool {
+	if rel == "" || filepath.IsAbs(rel) {
+		return false
+	}
+	clean := filepath.Clean(rel)
+	return clean == rel && clean != "." && !strings.HasPrefix(clean, ".."+string(os.PathSeparator)) && clean != ".."
 }
 
 // bootstrapPylonCommands writes embedded default commands into .pylon/commands/

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -144,6 +144,7 @@ func doctorSyncArgs(workspace string) []string {
 	if workspace != "" {
 		args = append(args, "--workspace", workspace)
 	}
+	args = append(args, "--yes")
 	return args
 }
 

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -83,8 +83,8 @@ func TestDoctorSyncArgs(t *testing.T) {
 		workspace string
 		want      []string
 	}{
-		{"no workspace override", "", []string{"doctor"}},
-		{"workspace override propagated", "/tmp/ws", []string{"doctor", "--workspace", "/tmp/ws"}},
+		{"no workspace override", "", []string{"doctor", "--yes"}},
+		{"workspace override propagated", "/tmp/ws", []string{"doctor", "--workspace", "/tmp/ws", "--yes"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 배경
`.claude/commands/`(Claude Code가 인식하는 슬래시 커맨드)는 `pylon launch`에서만 생성/갱신되었다. 그래서 `doctor`는 `.pylon/commands/`(소스)만 동기화하고 실제 커맨드는 stale 상태로 남아, 버전 업그레이드 후 `launch`를 다시 돌리기 전까지 커맨드가 최신화되지 않는 동기화 갭이 있었다.

## 변경
- `pylon doctor` 실행 시에도 `.claude/commands/`를 현행화한다.
- diff로 **추가/변경/삭제** 항목을 보여주고 **사용자 동의(기본 No)** 를 받은 경우에만 반영한다.
- `--yes` 플래그로 프롬프트를 건너뛸 수 있다(CI용).

```
🔄 Claude Code 커맨드 변경 사항:
  + pl/architect.md (추가)
  ~ pl/index.md (변경)
  - status.md (삭제)
적용하시겠습니까? [y/N]:
```

## 구현
- `buildDesiredClaudeCommands` / `applyClaudeCommands` / `bootstrapPylonCommands`로 커맨드 계산·쓰기 로직을 분리해 `launch`와 `doctor`가 단일 소스를 공유(서로 드리프트 방지). `generateClaudeDir`은 순수 리팩터링으로 출력 동일.
- `diffClaudeCommands` / `syncClaudeCommandsIfWorkspace`로 diff 출력 및 확인 프롬프트 처리(테스트 가능하도록 `io.Reader` 주입).
- 삭제는 레거시 커맨드 파일에 한정 → 사용자 커스텀 커맨드는 보존.

## 테스트
- desired keyset(11개), diff(추가/변경/삭제), 승인/거부/빈입력/`--yes`, `--yes` 플래그 검증 추가.
- `go vet`, 전체 테스트, 기존 launch 테스트 통과.

## 참고
`pylon init`은 `runDoctor`가 아닌 `RunDoctorChecks`를 호출하므로 이번 변경 범위 밖이다. init 직후 커맨드 생성이 필요하면 후속으로 반영 가능.