### PR TITLE
feat: doctor 실패 안내에 brew 설치 명령 추가

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -20,18 +20,20 @@ import (
 // Check represents a single dependency check.
 // Spec Reference: Section 7 "pylon doctor"
 type Check struct {
-	Name       string
-	Required   bool
-	Verify     func() (version string, err error)
-	InstallURL string
+	Name        string
+	Required    bool
+	Verify      func() (version string, err error)
+	InstallURL  string
+	BrewFormula string // Homebrew formula name; empty when brew install is not documented
 }
 
 var checks = []Check{
 	{
-		Name:       "fossil",
-		Required:   true,
-		Verify:     history.VerifyFossil,
-		InstallURL: "https://fossil-scm.org/home/uv/download.html",
+		Name:        "fossil",
+		Required:    true,
+		Verify:      history.VerifyFossil,
+		InstallURL:  "https://fossil-scm.org/home/uv/download.html",
+		BrewFormula: "fossil",
 	},
 	{
 		Name:       "git",
@@ -132,11 +134,28 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	printInstallHints(failures)
+	return fmt.Errorf("doctor checks failed")
+}
+
+// installHint returns the install guidance for a failed check.
+// When the tool has a brew formula and brew is available, the brew
+// command is shown first with the download URL as fallback.
+func installHint(c Check, hasBrew bool) string {
+	if c.BrewFormula != "" && hasBrew {
+		return fmt.Sprintf("brew install %s (또는 %s)", c.BrewFormula, c.InstallURL)
+	}
+	return c.InstallURL
+}
+
+// printInstallHints prints install guidance for each failed check.
+func printInstallHints(failures []Check) {
+	_, err := exec.LookPath("brew")
+	hasBrew := err == nil
 	fmt.Println("Some checks failed. Install missing tools:")
 	for _, f := range failures {
-		fmt.Printf("  %s: %s\n", f.Name, f.InstallURL)
+		fmt.Printf("  %s: %s\n", f.Name, installHint(f, hasBrew))
 	}
-	return fmt.Errorf("doctor checks failed")
 }
 
 // checkRepoExcludes verifies that all projects have .pylon/
@@ -239,10 +258,7 @@ func RunDoctorChecks() (bool, error) {
 
 	fmt.Println()
 	if !allPassed {
-		fmt.Println("Some checks failed. Install missing tools:")
-		for _, f := range failures {
-			fmt.Printf("  %s: %s\n", f.Name, f.InstallURL)
-		}
+		printInstallHints(failures)
 	}
 
 	return allPassed, nil

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -566,3 +566,26 @@ func TestResolveGitExcludePath_NotGitRepo(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestInstallHint_BrewFormulaWithBrew(t *testing.T) {
+	c := Check{Name: "fossil", InstallURL: "https://fossil-scm.org/home/uv/download.html", BrewFormula: "fossil"}
+	got := installHint(c, true)
+	want := "brew install fossil (또는 https://fossil-scm.org/home/uv/download.html)"
+	if got != want {
+		t.Errorf("installHint = %q, want %q", got, want)
+	}
+}
+
+func TestInstallHint_BrewFormulaWithoutBrew(t *testing.T) {
+	c := Check{Name: "fossil", InstallURL: "https://fossil-scm.org/home/uv/download.html", BrewFormula: "fossil"}
+	if got := installHint(c, false); got != c.InstallURL {
+		t.Errorf("installHint = %q, want %q", got, c.InstallURL)
+	}
+}
+
+func TestInstallHint_NoBrewFormula(t *testing.T) {
+	c := Check{Name: "git", InstallURL: "https://git-scm.com/downloads"}
+	if got := installHint(c, true); got != c.InstallURL {
+		t.Errorf("installHint = %q, want %q", got, c.InstallURL)
+	}
+}


### PR DESCRIPTION
## 요약
- fossil 미설치로 doctor 체크가 실패할 때 다운로드 URL만 안내되던 것을, brew가 PATH에 있는 환경에서는 `brew install fossil` 명령을 우선 안내하도록 개선
- `Check` 구조체에 `BrewFormula` 필드 추가 (fossil에만 지정, 나머지 도구는 기존 URL 안내 유지)
- `runDoctor`와 `RunDoctorChecks`에 중복돼 있던 실패 안내 출력을 `printInstallHints`로 공통화
- brew 감지는 `exec.LookPath("brew")` 기반이라 macOS 외 Linuxbrew 환경에서도 동작

## 출력 예시 (brew 있는 환경)
```
Some checks failed. Install missing tools:
  fossil: brew install fossil (또는 https://fossil-scm.org/home/uv/download.html)
```
brew가 없으면 기존과 동일하게 URL만 출력됩니다.

## 테스트
- `installHint` 단위 테스트 3개 추가 (brew 있음/없음, formula 미지정 도구)
- `go build ./...` 및 `go test ./...` 통과
- fossil 실패 스텁으로 doctor 실행해 실제 출력 확인