### PR TITLE
refactor: resolveRoot() 헬퍼 추출 및 워크스페이스 에러 메시지 한글 통일

### DIFF
--- a/internal/cli/add_agent.go
+++ b/internal/cli/add_agent.go
@@ -8,7 +8,6 @@ import (
 
 	"unicode"
 
-	"github.com/kyago/pylon/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -45,13 +44,9 @@ func runAddAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find workspace
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요")
+		return err
 	}
 
 	pylonDir := filepath.Join(root, ".pylon")

--- a/internal/cli/add_project.go
+++ b/internal/cli/add_project.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/store"
 )
 
@@ -42,13 +41,9 @@ func runAddProject(cmd *cobra.Command, args []string) error {
 	repoURL := args[0]
 
 	// Find workspace root
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("not in a pylon workspace — run 'pylon init' first")
+		return err
 	}
 
 	// Determine project name

--- a/internal/cli/add_skill.go
+++ b/internal/cli/add_skill.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kyago/pylon/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -28,13 +27,9 @@ func runAddSkill(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find workspace
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요")
+		return err
 	}
 
 	pylonDir := filepath.Join(root, ".pylon")

--- a/internal/cli/cancel.go
+++ b/internal/cli/cancel.go
@@ -27,13 +27,9 @@ func newCancelCmd() *cobra.Command {
 func runCancel(cmd *cobra.Command, args []string) error {
 	pipelineID := args[0]
 
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("not in a pylon workspace: %w", err)
+		return err
 	}
 
 	// v2: Try file-based cancellation first

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -163,11 +163,7 @@ func printInstallHints(failures []Check) {
 // When fix is true, missing entries are automatically added.
 // Returns true if all projects are OK, false if any are missing.
 func checkRepoExcludes(fix bool) bool {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
 		return true // not in a workspace, nothing to check
 	}
@@ -294,11 +290,7 @@ func verifyGH() (string, error) {
 
 // syncConfigIfWorkspace syncs config.yml defaults if running inside a pylon workspace.
 func syncConfigIfWorkspace() {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
 		return // not in a workspace, skip
 	}
@@ -325,11 +317,7 @@ func syncConfigIfWorkspace() {
 // whose content differs from the embedded version are refreshed, so upgrades
 // pick up new resource content.
 func syncResourcesIfWorkspace() {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
 		return // not in a workspace, skip
 	}
@@ -470,11 +458,7 @@ func diffClaudeCommands(commandsDir string, desired map[string]string) commandDi
 // changes after the user consents (default: No). When autoYes is true the prompt
 // is skipped and changes are applied automatically.
 func syncClaudeCommandsIfWorkspace(in io.Reader, autoYes bool) {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
 		return // not in a workspace, skip
 	}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -28,13 +28,9 @@ var embeddedCommands embed.FS
 // Claude Code TUI directly via syscall.Exec.
 func runLaunch() error {
 	// Step 1: Find workspace
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요")
+		return err
 	}
 
 	// Step 2: Load config
@@ -107,13 +103,9 @@ func prepareHistory(root string, cfg config.HistoryConfig) error {
 // openWorkspaceStore is a shared helper that finds the workspace root, loads config,
 // and opens the SQLite store. Caller must close the returned Store.
 func openWorkspaceStore() (string, *config.Config, *store.Store, error) {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return "", nil, nil, fmt.Errorf("not in a pylon workspace")
+		return "", nil, nil, err
 	}
 
 	cfg, err := config.LoadConfig(filepath.Join(root, ".pylon", "config.yml"))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
-	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/domain"
 )
 
@@ -24,13 +23,9 @@ Shows file-based v2 pipelines (.pylon/runtime/).`,
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("not in a pylon workspace: %w", err)
+		return err
 	}
 
 	fmt.Println("Pylon Status")

--- a/internal/cli/sync_agents.go
+++ b/internal/cli/sync_agents.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/kyago/pylon/internal/config"
 )
 
 func newSyncAgentsCmd() *cobra.Command {
@@ -38,13 +36,9 @@ pylon에 내장된 최신 에이전트 템플릿(.pylon/agents/)을 설치하고
 }
 
 func runSyncAgents(force bool) error {
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요")
+		return err
 	}
 
 	pylonDir := filepath.Join(root, ".pylon")

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -57,13 +57,9 @@ func runUninstall(cmd *cobra.Command, args []string) error {
 	removeBinary, _ := cmd.Flags().GetBool("remove-binary")
 
 	// Find workspace
-	startDir := flagWorkspace
-	if startDir == "" {
-		startDir = "."
-	}
-	root, err := config.FindWorkspaceRoot(startDir)
+	root, err := resolveRoot()
 	if err != nil {
-		return fmt.Errorf("not in a pylon workspace: %w", err)
+		return err
 	}
 
 	// Build uninstall plan

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/kyago/pylon/internal/config"
+)
+
+// resolveRoot finds the pylon workspace root, starting from the --workspace
+// flag value (or the current directory when unset). All commands share this
+// helper so the "not a workspace" error message stays consistent.
+func resolveRoot() (string, error) {
+	startDir := flagWorkspace
+	if startDir == "" {
+		startDir = "."
+	}
+	root, err := config.FindWorkspaceRoot(startDir)
+	if err != nil {
+		return "", fmt.Errorf("pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요")
+	}
+	return root, nil
+}

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRoot(t *testing.T) {
+	t.Run("워크스페이스가 아니면 한글 에러를 반환한다", func(t *testing.T) {
+		dir := t.TempDir()
+		orig := flagWorkspace
+		flagWorkspace = dir
+		defer func() { flagWorkspace = orig }()
+
+		_, err := resolveRoot()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		want := "pylon 워크스페이스가 아닙니다 — 'pylon init'을 먼저 실행하세요"
+		if err.Error() != want {
+			t.Errorf("error = %q, want %q", err.Error(), want)
+		}
+	})
+
+	t.Run("워크스페이스 루트를 찾는다", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, ".pylon"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".pylon", "config.yml"), []byte("version: \"0.1\"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		sub := filepath.Join(dir, "sub")
+		if err := os.MkdirAll(sub, 0755); err != nil {
+			t.Fatal(err)
+		}
+		orig := flagWorkspace
+		flagWorkspace = sub
+		defer func() { flagWorkspace = orig }()
+
+		root, err := resolveRoot()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		resolved, _ := filepath.EvalSymlinks(dir)
+		got, _ := filepath.EvalSymlinks(root)
+		if got != resolved {
+			t.Errorf("root = %q, want %q", got, resolved)
+		}
+	})
+}


### PR DESCRIPTION
## 요약
- 9개 파일 13곳에 복붙되어 있던 워크스페이스 루트 탐색 블록(`flagWorkspace` → `config.FindWorkspaceRoot`)을 `internal/cli/workspace.go`의 `resolveRoot()` 헬퍼로 통합
- `openWorkspaceStore()`도 내부적으로 `resolveRoot()`를 사용하도록 변경
- "워크스페이스 아님" 에러 메시지를 한글 문구로 통일 — 기존에는 같은 조건에서 한글 4곳/영어 5곳(3가지 변형)으로 갈렸음
- `resolveRoot()` 단위 테스트 추가

## 동작 변경 여부
리팩토링 — 유일한 사용자 가시 변경은 사전 합의된 에러 메시지 한글 통일뿐 (`cancel`/`status`/`uninstall`/`add-project` 및 store 기반 커맨드가 영어 대신 한글 에러 출력).

## 검증
- `go build ./... && go vet ./... && go test ./...` 통과
- 워크스페이스 밖에서 `status`/`cancel`/`add-project` 실행 시 동일 한글 에러 확인
- `FindWorkspaceRoot` 직접 호출은 `workspace.go` 헬퍼 정의부 1곳만 잔존