### PR TITLE
refactor: layout 패키지로 워크스페이스 경로 리터럴 중앙화

### DIFF
--- a/internal/cli/add_agent.go
+++ b/internal/cli/add_agent.go
@@ -8,6 +8,7 @@ import (
 
 	"unicode"
 
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,7 @@ func runAddAgent(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	agentPath := filepath.Join(pylonDir, "agents", name+".md")
 
 	// Check if already exists

--- a/internal/cli/add_project.go
+++ b/internal/cli/add_project.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/kyago/pylon/internal/store"
 )
 
@@ -105,7 +106,7 @@ func runAddProject(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 2: Create project .pylon/ structure
-	pylonDir := filepath.Join(projectDir, ".pylon")
+	pylonDir := layout.PylonDir(projectDir)
 	agentsDir := filepath.Join(pylonDir, "agents")
 	if err := os.MkdirAll(agentsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create project .pylon/: %w", err)
@@ -277,11 +278,11 @@ func excludePylonFromRepo(projectDir string) error {
 
 // techStack holds detected technology information.
 type techStack struct {
-	Language   string
-	Framework  string
-	HasTests   bool
-	BuildTool  string
-	LintTool   string
+	Language  string
+	Framework string
+	HasTests  bool
+	BuildTool string
+	LintTool  string
 }
 
 // detectTechStack analyzes the project directory to identify technologies.
@@ -573,7 +574,7 @@ func generateVerifyYML(stack techStack) string {
 }
 
 func registerProjectInDB(root, projectName, projectDir, stackLang string) error {
-	dbPath := filepath.Join(root, ".pylon", "pylon.db")
+	dbPath := layout.DBPath(root)
 	s, err := store.NewStore(dbPath)
 	if err != nil {
 		return fmt.Errorf("store open: %w", err)

--- a/internal/cli/add_skill.go
+++ b/internal/cli/add_skill.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ func runAddSkill(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	skillPath := filepath.Join(pylonDir, "skills", name+".md")
 
 	// Ensure skills directory exists

--- a/internal/cli/cancel.go
+++ b/internal/cli/cancel.go
@@ -8,19 +8,20 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/history"
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/kyago/pylon/internal/store"
+	"github.com/spf13/cobra"
 )
 
 func newCancelCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "cancel [pipeline-id]",
 		Short: "Cancel a running pipeline",
-		Long: `Cancel a running pipeline (file-based v2 pipelines under .pylon/runtime/).`,
-		Args: cobra.ExactArgs(1),
-		RunE: runCancel,
+		Long:  `Cancel a running pipeline (file-based v2 pipelines under .pylon/runtime/).`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runCancel,
 	}
 }
 
@@ -33,7 +34,7 @@ func runCancel(cmd *cobra.Command, args []string) error {
 	}
 
 	// v2: Try file-based cancellation first
-	pipelineDir := filepath.Join(root, ".pylon", "runtime", pipelineID)
+	pipelineDir := filepath.Join(layout.RuntimeDir(root), pipelineID)
 	if _, err := os.Stat(pipelineDir); err == nil {
 		// Read existing status.json for branch info BEFORE overwriting
 		var branch string
@@ -57,8 +58,8 @@ func runCancel(cmd *cobra.Command, args []string) error {
 		// deleted without losing history. Best effort: on failure we fall back
 		// to preserving the runtime directory.
 		checkpointed := false
-		if cfg, cfgErr := config.LoadConfig(filepath.Join(root, ".pylon", "config.yml")); cfgErr == nil {
-			if s, storeErr := store.NewStore(filepath.Join(root, ".pylon", "pylon.db")); storeErr == nil {
+		if cfg, cfgErr := config.LoadConfig(layout.ConfigPath(root)); cfgErr == nil {
+			if s, storeErr := store.NewStore(layout.DBPath(root)); storeErr == nil {
 				if s.Migrate() == nil {
 					mgr := history.NewManager(root, cfg.History, s, nil)
 					if _, cpErr := mgr.Checkpoint(pipelineID, history.PhaseCancelled); cpErr == nil {
@@ -70,7 +71,7 @@ func runCancel(cmd *cobra.Command, args []string) error {
 		}
 
 		// Run cleanup script if available
-		cleanupScript := filepath.Join(root, ".pylon", "scripts", "bash", "cleanup-pipeline.sh")
+		cleanupScript := filepath.Join(layout.ScriptsDir(root), "cleanup-pipeline.sh")
 		if _, err := os.Stat(cleanupScript); err == nil {
 			cleanup := exec.Command("bash", cleanupScript, pipelineDir, branch, fmt.Sprintf("%t", checkpointed))
 			cleanup.Dir = root

--- a/internal/cli/delete_project.go
+++ b/internal/cli/delete_project.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +64,7 @@ func runDeleteProject(name string, purge, force bool) error {
 		if purge {
 			removeTarget = projDir
 		} else {
-			marker := filepath.Join(projDir, ".pylon")
+			marker := layout.PylonDir(projDir)
 			if dirExists(marker) {
 				removeTarget = marker
 			}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/history"
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -295,7 +296,7 @@ func syncConfigIfWorkspace() {
 		return // not in a workspace, skip
 	}
 
-	cfgPath := filepath.Join(root, ".pylon", "config.yml")
+	cfgPath := layout.ConfigPath(root)
 	_, added, err := config.SyncConfigDefaults(cfgPath)
 	if err != nil {
 		fmt.Printf("⚠ 설정 동기화 실패: %v\n", err)
@@ -322,7 +323,7 @@ func syncResourcesIfWorkspace() {
 		return // not in a workspace, skip
 	}
 
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	var totalWritten int
 
 	// Sync agents
@@ -463,7 +464,7 @@ func syncClaudeCommandsIfWorkspace(in io.Reader, autoYes bool) {
 		return // not in a workspace, skip
 	}
 
-	commandsDir := filepath.Join(root, ".claude", "commands")
+	commandsDir := layout.ClaudeCommandsDir(root)
 	desired := buildDesiredClaudeCommands(root)
 	diff := diffClaudeCommands(commandsDir, desired)
 

--- a/internal/cli/init_cmd.go
+++ b/internal/cli/init_cmd.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/history"
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/kyago/pylon/internal/store"
 )
 
@@ -60,7 +61,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 2: Check if .pylon/ already exists
-	pylonDir := filepath.Join(workDir, ".pylon")
+	pylonDir := layout.PylonDir(workDir)
 	if _, err := os.Stat(pylonDir); err == nil {
 		return fmt.Errorf(".pylon/ already exists in %s. Use 'pylon uninstall' to remove it first", workDir)
 	}

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/kyago/pylon/internal/config"
 	"github.com/kyago/pylon/internal/history"
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/kyago/pylon/internal/store"
 )
 
@@ -34,7 +35,7 @@ func runLaunch() error {
 	}
 
 	// Step 2: Load config
-	cfg, err := config.LoadConfig(filepath.Join(root, ".pylon", "config.yml"))
+	cfg, err := config.LoadConfig(layout.ConfigPath(root))
 	if err != nil {
 		return fmt.Errorf("설정 로드 실패: %w", err)
 	}
@@ -108,12 +109,12 @@ func openWorkspaceStore() (string, *config.Config, *store.Store, error) {
 		return "", nil, nil, err
 	}
 
-	cfg, err := config.LoadConfig(filepath.Join(root, ".pylon", "config.yml"))
+	cfg, err := config.LoadConfig(layout.ConfigPath(root))
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	dbPath := filepath.Join(root, ".pylon", "pylon.db")
+	dbPath := layout.DBPath(root)
 	s, err := store.NewStore(dbPath)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to open store: %w", err)
@@ -179,7 +180,7 @@ func buildClaudeArgs(cfg *config.Config, permMode string) []string {
 
 // generateClaudeDir creates/updates the .claude/ directory from .pylon/ source of truth.
 func generateClaudeDir(root string, cfg *config.Config, projects []config.ProjectInfo) error {
-	claudeDir := filepath.Join(root, ".claude")
+	claudeDir := layout.ClaudeDir(root)
 	commandsDir := filepath.Join(claudeDir, "commands")
 
 	// Ensure directories exist
@@ -201,13 +202,13 @@ func generateClaudeDir(root string, cfg *config.Config, projects []config.Projec
 	}
 
 	// Bootstrap .pylon/commands/ from embedded defaults for future customization
-	if err := bootstrapPylonCommands(filepath.Join(root, ".pylon", "commands")); err != nil {
+	if err := bootstrapPylonCommands(layout.CommandsDir(root)); err != nil {
 		return err
 	}
 
 	// Pipeline scripts → .pylon/scripts/bash/
 	// Bootstrap embedded scripts if workspace doesn't have them yet (existing workspaces)
-	pylonScriptsDir := filepath.Join(root, ".pylon", "scripts", "bash")
+	pylonScriptsDir := layout.ScriptsDir(root)
 	if err := os.MkdirAll(pylonScriptsDir, 0755); err != nil {
 		return fmt.Errorf("scripts/bash/ 디렉토리 생성 실패: %w", err)
 	}
@@ -339,7 +340,7 @@ func buildRootCLAUDEMD(cfg *config.Config, projects []config.ProjectInfo, root s
 	b.WriteString("`isolation: \"worktree\"` 옵션으로 git worktree 격리를 사용합니다.\n\n")
 
 	// Discover agents by domain and list them
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	agentsByDomain := discoverAgentsByDomain(pylonDir)
 	domainOrder := []string{"software", "research", "content", "marketing"}
 	domainLabels := map[string]string{
@@ -527,7 +528,7 @@ func buildDesiredClaudeCommands(root string) map[string]string {
 
 	// Pipeline slash commands → pl/: prefer .pylon/commands/ (user customization),
 	// fall back to embedded defaults for workspaces without .pylon/commands/.
-	pylonCmdsDir := filepath.Join(root, ".pylon", "commands")
+	pylonCmdsDir := layout.CommandsDir(root)
 	if entries, err := os.ReadDir(pylonCmdsDir); err == nil && len(entries) > 0 {
 		for _, entry := range entries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
@@ -703,9 +704,9 @@ func addClaudeDirToGitignore(root string) error {
 // For agents without skills: creates a symlink to .pylon/agents/ (default behavior).
 // Respects SkillsConfig flags: Enabled, PreloadToAgents, ProgressiveDisclosure.
 func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	pylonAgentsDir := filepath.Join(pylonDir, "agents")
-	claudeAgentsDir := filepath.Join(root, ".claude", "agents")
+	claudeAgentsDir := layout.ClaudeAgentsDir(root)
 	skillsDir := filepath.Join(pylonDir, "skills")
 
 	if err := os.MkdirAll(claudeAgentsDir, 0755); err != nil {
@@ -745,13 +746,13 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 		agent, err := config.ParseAgentFile(agentPath)
 		if err != nil {
 			// Unparseable agent — fall back to symlink
-			ensureSymlink(linkPath, filepath.Join("..", "..", ".pylon", "agents", entry.Name()))
+			ensureSymlink(linkPath, layout.AgentLinkTarget(entry.Name()))
 			continue
 		}
 
 		// If skills disabled or agent has no skills, use symlink
 		if !cfg.Skills.Enabled || !cfg.Skills.PreloadToAgents || len(agent.Skills) == 0 {
-			ensureSymlink(linkPath, filepath.Join("..", "..", ".pylon", "agents", entry.Name()))
+			ensureSymlink(linkPath, layout.AgentLinkTarget(entry.Name()))
 			continue
 		}
 
@@ -764,7 +765,7 @@ func generateClaudeAgentsWithSkills(root string, cfg *config.Config) error {
 		injected := buildSkillInjection(agent.Skills, skillMap, cfg.Skills.ProgressiveDisclosure)
 		if injected == "" {
 			// No matching skills found, use symlink
-			ensureSymlink(linkPath, filepath.Join("..", "..", ".pylon", "agents", entry.Name()))
+			ensureSymlink(linkPath, layout.AgentLinkTarget(entry.Name()))
 			continue
 		}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/spf13/cobra"
 	"github.com/kyago/pylon/internal/domain"
+	"github.com/kyago/pylon/internal/layout"
+	"github.com/spf13/cobra"
 )
 
 func newStatusCmd() *cobra.Command {
@@ -34,7 +35,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	foundAny := false
 
 	// v2: Show file-based pipeline status
-	runtimeDir := filepath.Join(root, ".pylon", "runtime")
+	runtimeDir := layout.RuntimeDir(root)
 	if entries, dirErr := os.ReadDir(runtimeDir); dirErr == nil {
 		for _, entry := range entries {
 			if !entry.IsDir() {

--- a/internal/cli/sync_agents.go
+++ b/internal/cli/sync_agents.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -41,7 +42,7 @@ func runSyncAgents(force bool) error {
 		return err
 	}
 
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	agentsDir := filepath.Join(pylonDir, "agents")
 	if err := os.MkdirAll(agentsDir, 0755); err != nil {
 		return fmt.Errorf("agents 디렉토리 생성 실패: %w", err)
@@ -102,7 +103,7 @@ func runSyncAgents(force bool) error {
 
 // syncClaudeAgentLinks ensures .claude/agents/ has symlinks for all .pylon/agents/*.md files.
 func syncClaudeAgentLinks(workDir, pylonDir string) error {
-	claudeAgentsDir := filepath.Join(workDir, ".claude", "agents")
+	claudeAgentsDir := layout.ClaudeAgentsDir(workDir)
 	if err := os.MkdirAll(claudeAgentsDir, 0755); err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func syncClaudeAgentLinks(workDir, pylonDir string) error {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
 			continue
 		}
-		relTarget := filepath.Join("..", "..", ".pylon", "agents", entry.Name())
+		relTarget := layout.AgentLinkTarget(entry.Name())
 		linkPath := filepath.Join(claudeAgentsDir, entry.Name())
 
 		// 기존 심링크가 있으면 제거 후 재생성 (대상이 변경됐을 수 있음)

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kyago/pylon/internal/config"
+	"github.com/kyago/pylon/internal/layout"
 )
 
 func newUninstallCmd() *cobra.Command {
@@ -96,7 +97,7 @@ func buildUninstallPlan(root string, removeProjects, removeBinary bool) (*uninst
 	plan := &uninstallPlan{}
 
 	// 1. Runtime artifacts
-	claudeDir := filepath.Join(root, ".claude")
+	claudeDir := layout.ClaudeDir(root)
 	if dirExists(claudeDir) {
 		plan.runtimeFiles = append(plan.runtimeFiles, claudeDir)
 	}
@@ -111,7 +112,7 @@ func buildUninstallPlan(root string, removeProjects, removeBinary bool) (*uninst
 		return nil, fmt.Errorf("failed to discover projects: %w", err)
 	}
 	for _, p := range projects {
-		projectPylon := filepath.Join(p.Path, ".pylon")
+		projectPylon := layout.PylonDir(p.Path)
 		if dirExists(projectPylon) {
 			plan.projectPylons = append(plan.projectPylons, projectPylon)
 		}
@@ -121,7 +122,7 @@ func buildUninstallPlan(root string, removeProjects, removeBinary bool) (*uninst
 	}
 
 	// 3. Workspace .pylon/
-	pylonDir := filepath.Join(root, ".pylon")
+	pylonDir := layout.PylonDir(root)
 	if dirExists(pylonDir) {
 		plan.workspacePylon = pylonDir
 	}

--- a/internal/layout/layout.go
+++ b/internal/layout/layout.go
@@ -1,0 +1,62 @@
+// Package layout centralizes the well-known paths inside a pylon workspace.
+// All ".pylon" / ".claude" path construction should go through these helpers
+// so the directory layout is defined in exactly one place.
+package layout
+
+import "path/filepath"
+
+// PylonDir returns the .pylon directory under the given workspace root.
+func PylonDir(root string) string {
+	return filepath.Join(root, ".pylon")
+}
+
+// ConfigPath returns the workspace config file path (.pylon/config.yml).
+func ConfigPath(root string) string {
+	return filepath.Join(PylonDir(root), "config.yml")
+}
+
+// DBPath returns the SQLite store path (.pylon/pylon.db).
+func DBPath(root string) string {
+	return filepath.Join(PylonDir(root), "pylon.db")
+}
+
+// RuntimeDir returns the pipeline runtime state directory (.pylon/runtime).
+func RuntimeDir(root string) string {
+	return filepath.Join(PylonDir(root), "runtime")
+}
+
+// AgentsDir returns the agent definition directory (.pylon/agents).
+func AgentsDir(root string) string {
+	return filepath.Join(PylonDir(root), "agents")
+}
+
+// CommandsDir returns the pipeline command directory (.pylon/commands).
+func CommandsDir(root string) string {
+	return filepath.Join(PylonDir(root), "commands")
+}
+
+// ScriptsDir returns the pipeline bash script directory (.pylon/scripts/bash).
+func ScriptsDir(root string) string {
+	return filepath.Join(PylonDir(root), "scripts", "bash")
+}
+
+// ClaudeDir returns the Claude CLI directory under the workspace root (.claude).
+func ClaudeDir(root string) string {
+	return filepath.Join(root, ".claude")
+}
+
+// ClaudeAgentsDir returns the Claude agent discovery directory (.claude/agents).
+func ClaudeAgentsDir(root string) string {
+	return filepath.Join(ClaudeDir(root), "agents")
+}
+
+// ClaudeCommandsDir returns the Claude slash command directory (.claude/commands).
+func ClaudeCommandsDir(root string) string {
+	return filepath.Join(ClaudeDir(root), "commands")
+}
+
+// AgentLinkTarget returns the relative symlink target used inside
+// .claude/agents/ to point at .pylon/agents/<name>.
+func AgentLinkTarget(name string) string {
+	return filepath.Join("..", "..", ".pylon", "agents", name)
+}

--- a/internal/layout/layout_test.go
+++ b/internal/layout/layout_test.go
@@ -1,0 +1,32 @@
+package layout
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLayoutPaths(t *testing.T) {
+	root := filepath.Join("some", "root")
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"PylonDir", PylonDir(root), filepath.Join(root, ".pylon")},
+		{"ConfigPath", ConfigPath(root), filepath.Join(root, ".pylon", "config.yml")},
+		{"DBPath", DBPath(root), filepath.Join(root, ".pylon", "pylon.db")},
+		{"RuntimeDir", RuntimeDir(root), filepath.Join(root, ".pylon", "runtime")},
+		{"AgentsDir", AgentsDir(root), filepath.Join(root, ".pylon", "agents")},
+		{"CommandsDir", CommandsDir(root), filepath.Join(root, ".pylon", "commands")},
+		{"ScriptsDir", ScriptsDir(root), filepath.Join(root, ".pylon", "scripts", "bash")},
+		{"ClaudeDir", ClaudeDir(root), filepath.Join(root, ".claude")},
+		{"ClaudeAgentsDir", ClaudeAgentsDir(root), filepath.Join(root, ".claude", "agents")},
+		{"ClaudeCommandsDir", ClaudeCommandsDir(root), filepath.Join(root, ".claude", "commands")},
+		{"AgentLinkTarget", AgentLinkTarget("a.md"), filepath.Join("..", "..", ".pylon", "agents", "a.md")},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## 요약
- `internal/layout` 패키지를 신설해 `.pylon`/`.claude` 하위 경로 헬퍼(`PylonDir`, `ConfigPath`, `DBPath`, `RuntimeDir`, `AgentsDir`, `CommandsDir`, `ScriptsDir`, `ClaudeDir`, `ClaudeAgentsDir`, `ClaudeCommandsDir`, `AgentLinkTarget`)를 한곳에 정의
- `internal/cli` 11개 파일에 흩어져 있던 경로 리터럴 조립 31곳을 헬퍼 호출로 교체
- 심링크 상대 경로 `"..","..",".pylon","agents"` 4회 반복을 `AgentLinkTarget`으로 통합
- layout 패키지 단위 테스트 추가

## 동작 변경 여부
리팩토링 — 생성되는 경로는 byte-동일. 사용자 가시 변경 없음.

## 검증
- `go build ./... && go vet ./... && go test ./...` 통과
- `grep -rn '"\.pylon"\|"\.claude"' internal/cli --include='*.go'` (테스트 제외) 결과 0건 — 리터럴은 layout 정의부에만 존재
- 임시 워크스페이스에서 `pylon init` → agents 38개, `.claude/agents/` 심링크 생성, `pylon status` 정상 출력 확인