### PR TITLE
refactor: add-agent/add-skill 스캐폴딩 병합

### DIFF
--- a/internal/cli/add_agent.go
+++ b/internal/cli/add_agent.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"unicode"
@@ -44,20 +42,6 @@ func runAddAgent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--role 플래그가 필요합니다 (예: --role \"Backend Developer\")")
 	}
 
-	// Find workspace
-	root, err := resolveRoot()
-	if err != nil {
-		return err
-	}
-
-	pylonDir := layout.PylonDir(root)
-	agentPath := filepath.Join(pylonDir, "agents", name+".md")
-
-	// Check if already exists
-	if _, err := os.Stat(agentPath); err == nil {
-		return fmt.Errorf("에이전트 '%s'가 이미 존재합니다: %s", name, agentPath)
-	}
-
 	// Capitalize for display (avoid deprecated strings.Title)
 	displayName := toTitleCase(strings.ReplaceAll(name, "-", " "))
 
@@ -80,13 +64,16 @@ domain: %s
 4. Deliver results
 `, name, addAgentRole, addAgentDomain, displayName, addAgentRole)
 
-	if err := os.WriteFile(agentPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("에이전트 파일 생성 실패: %w", err)
+	agentPath, err := scaffoldMarkdownResource("에이전트", "agents", name, content)
+	if err != nil {
+		return err
 	}
 
 	// Sync Claude agent symlinks
-	if err := syncClaudeAgentLinks(root, pylonDir); err != nil {
-		fmt.Printf("⚠ .claude/agents/ 심링크 갱신 실패: %v\n", err)
+	if root, rerr := resolveRoot(); rerr == nil {
+		if err := syncClaudeAgentLinks(root, layout.PylonDir(root)); err != nil {
+			fmt.Printf("⚠ .claude/agents/ 심링크 갱신 실패: %v\n", err)
+		}
 	}
 
 	fmt.Printf("✓ 에이전트 '%s' 생성 완료: %s\n", name, agentPath)

--- a/internal/cli/add_skill.go
+++ b/internal/cli/add_skill.go
@@ -2,11 +2,8 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/kyago/pylon/internal/layout"
 	"github.com/spf13/cobra"
 )
 
@@ -25,26 +22,6 @@ func runAddSkill(cmd *cobra.Command, args []string) error {
 	name := strings.TrimSpace(args[0])
 	if name == "" {
 		return fmt.Errorf("스킬 이름이 비어있습니다")
-	}
-
-	// Find workspace
-	root, err := resolveRoot()
-	if err != nil {
-		return err
-	}
-
-	pylonDir := layout.PylonDir(root)
-	skillPath := filepath.Join(pylonDir, "skills", name+".md")
-
-	// Ensure skills directory exists
-	skillsDir := filepath.Join(pylonDir, "skills")
-	if err := os.MkdirAll(skillsDir, 0755); err != nil {
-		return fmt.Errorf("skills 디렉토리 생성 실패: %w", err)
-	}
-
-	// Check if already exists
-	if _, err := os.Stat(skillPath); err == nil {
-		return fmt.Errorf("스킬 '%s'가 이미 존재합니다: %s", name, skillPath)
 	}
 
 	// Generate skill template
@@ -68,8 +45,9 @@ description: "%s 스킬 — 설명을 작성하세요"
 3. 세 번째 단계
 `, name, displayName, displayName)
 
-	if err := os.WriteFile(skillPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("스킬 파일 생성 실패: %w", err)
+	skillPath, err := scaffoldMarkdownResource("스킬", "skills", name, content)
+	if err != nil {
+		return err
 	}
 
 	fmt.Printf("✓ 스킬 '%s' 생성 완료: %s\n", name, skillPath)

--- a/internal/cli/scaffold.go
+++ b/internal/cli/scaffold.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kyago/pylon/internal/layout"
+)
+
+// scaffoldMarkdownResource creates .pylon/<subdir>/<name>.md with the given
+// template content, shared by add-agent and add-skill. kind is the user-facing
+// resource label ("에이전트", "스킬") used in error messages. The subdirectory is
+// created if missing, and an existing file is never overwritten. Returns the
+// created file path.
+func scaffoldMarkdownResource(kind, subdir, name, content string) (string, error) {
+	root, err := resolveRoot()
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(layout.PylonDir(root), subdir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", fmt.Errorf("%s 디렉토리 생성 실패: %w", subdir, err)
+	}
+
+	path := filepath.Join(dir, name+".md")
+	if _, err := os.Stat(path); err == nil {
+		return "", fmt.Errorf("%s '%s'가 이미 존재합니다: %s", kind, name, path)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return "", fmt.Errorf("%s 파일 생성 실패: %w", kind, err)
+	}
+
+	return path, nil
+}

--- a/internal/cli/scaffold_test.go
+++ b/internal/cli/scaffold_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newScaffoldWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".pylon"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".pylon", "config.yml"), []byte("version: \"0.1\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	orig := flagWorkspace
+	flagWorkspace = dir
+	t.Cleanup(func() { flagWorkspace = orig })
+	return dir
+}
+
+func TestScaffoldMarkdownResource(t *testing.T) {
+	t.Run("파일을 생성하고 내용이 byte-동일하다", func(t *testing.T) {
+		dir := newScaffoldWorkspace(t)
+		content := "---\nname: x\n---\n\n# X\n"
+
+		path, err := scaffoldMarkdownResource("에이전트", "agents", "x", content)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := filepath.Join(dir, ".pylon", "agents", "x.md")
+		if path != want {
+			t.Errorf("path = %q, want %q", path, want)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != content {
+			t.Errorf("content mismatch:\ngot:  %q\nwant: %q", got, content)
+		}
+	})
+
+	t.Run("하위 디렉토리가 없으면 생성한다", func(t *testing.T) {
+		dir := newScaffoldWorkspace(t)
+		if _, err := os.Stat(filepath.Join(dir, ".pylon", "skills")); !os.IsNotExist(err) {
+			t.Fatal("precondition: skills dir must not exist")
+		}
+		if _, err := scaffoldMarkdownResource("스킬", "skills", "s", "body"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("이미 존재하면 kind 가 포함된 에러를 반환한다", func(t *testing.T) {
+		dir := newScaffoldWorkspace(t)
+		existing := filepath.Join(dir, ".pylon", "skills")
+		if err := os.MkdirAll(existing, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(existing, "dup.md"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err := scaffoldMarkdownResource("스킬", "skills", "dup", "new")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		wantPrefix := "스킬 'dup'가 이미 존재합니다"
+		if len(err.Error()) < len(wantPrefix) || err.Error()[:len(wantPrefix)] != wantPrefix {
+			t.Errorf("error = %q, want prefix %q", err.Error(), wantPrefix)
+		}
+	})
+}


### PR DESCRIPTION
## 요약
- `add_agent.go`/`add_skill.go`에 복붙되어 있던 스캐폴딩 흐름(워크스페이스 탐색 → 디렉토리 준비 → `os.Stat` 존재 검사 → `os.WriteFile(0644)`)을 `scaffold.go`의 `scaffoldMarkdownResource(kind, subdir, name, content)` 공용 헬퍼로 병합
- 차이점(이름·역할 검증, 템플릿 본문, add-agent의 심링크 동기화, 성공 출력)은 각 커맨드에 유지
- 헬퍼 단위 테스트 3건 추가 (TDD — 실패 테스트 선행)

## 동작 변경 여부
- 템플릿·생성 파일·성공 출력은 리팩토링 전과 **byte-동일** (전/후 바이너리로 생성물 diff 검증)
- 유일한 신규 동작: `add-agent`도 `agents/` 디렉토리가 없으면 생성 (기존에는 add-skill만 MkdirAll — 통일). 테스트로 커버

## 검증
- `go build ./... && go vet ./... && go test ./...` 통과
- 전/후 바이너리로 임시 워크스페이스에서 `add-agent`/`add-skill` 실행 → 생성 파일·stdout 모두 동일