### PR TITLE
fix(ci): setup-go v7로 올려 lint 잡 복구

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       # 배포 바이너리 대신 소스에서 빌드한다. golangci-lint-action이 설치하는
       # 바이너리는 go.mod의 toolchain(go1.26)보다 낮은 Go로 빌드돼 있어
       # "the Go language version used to build golangci-lint is lower than the
-      # targeted Go version" 으로 린트가 아예 실행되지 않았다. go install은 이
-      # 잡의 Go 툴체인으로 빌드하므로 버전이 어긋날 수 없다.
+      # targeted Go version" 으로 린트가 아예 실행되지 않았다.
+      #
+      # 단 go install만으로는 부족하다 — 이 스텝이 쓰는 Go 자체가 충분히 높아야 한다.
+      # setup-go는 v6.0.0부터 go.mod의 toolchain 지시자를 읽는다. v5는 go 지시자(1.24.0)만
+      # 보고 Go 1.24를 깔았고, 그 상태의 go install은 golangci-lint를 그 모듈 기준
+      # 툴체인(go1.25)으로 빌드해 위 에러가 그대로 재발했다. 그래서 v7로 고정한다.
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
@@ -36,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
@@ -50,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
## 문제

CI의 `lint` 잡이 최소 2026-07-31부터 `main`에서 계속 실패하고 있었다. 코드가 아니라
린터가 아예 실행되지 못하는 상태였다.

```
Error: can't load config: the Go language version (go1.25) used to build
golangci-lint is lower than the targeted Go version (1.26.0)
```

`build` / `test` 잡은 통과하므로 눈에 잘 띄지 않았다.

## 원인

`actions/setup-go`가 `go.mod`의 **`toolchain` 지시자를 읽기 시작한 건 v6.0.0**부터다
(v6.0.0 릴리스 노트: "Improve toolchain handling to ensure more reliable and consistent
toolchain selection and management"). 워크플로는 `@v5`로 고정돼 있어 `go` 지시자만 보고
Go **1.24.0**을 설치했다.

`go build` / `go test`는 Go 자체의 툴체인 자동 다운로드가 `toolchain go1.26.0`을 끌어와
정상 동작했다. 하지만 `go install golangci-lint@v2.12.2`는 **golangci-lint 자기 모듈의**
툴체인 기준으로 빌드되므로 go1.25 바이너리가 나왔고, 그 바이너리가 이 저장소의
go1.26.0 타깃을 거부했다.

즉 기존 주석의 "go install은 이 잡의 Go 툴체인으로 빌드하므로 버전이 어긋날 수 없다"는
전제가 틀렸다 — 그 잡의 Go가 낮으면 그대로 낮게 빌드된다.

## 변경

- `actions/setup-go@v5` → `@v7` (세 잡 모두). 이제 `go-version-file: go.mod`가
  `toolchain go1.26.0`을 반영해 Go 1.26을 설치하고, `go install`도 1.26으로 빌드한다.
- lint 잡 주석을 실제 실패 원인에 맞게 갱신했다.

## 검증

로컬 golangci-lint는 go1.26.2로 빌드돼 있어 `make lint`가 0 issues로 통과한다 —
CI만 재현되던 문제라, 이 PR의 CI 실행 결과가 검증이다.
