### PR TITLE
ci: goreleaser-action v7 + deprecated archives.format 정리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+dist/
 pylon
 *.db
 *.db-wal

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,12 +16,12 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## 변경

### 1. `goreleaser-action@v6` → `@v7`

v7의 breaking change는 `version` 입력 기본값이 v1 → `"~> v2"`로 바뀐 것인데
(릴리스 노트: `feat!: use "~> v2" as default`), 이 워크플로는 이미
`version: "~> v2"`를 명시하고 있어 해당되지 않는다. `.goreleaser.yml`도 `version: 2`다.

### 2. deprecated `archives.format` → `formats`

`goreleaser check`가 경고하던 항목이다. 지금은 "valid, but uses deprecated properties"
상태로 통과하지만 향후 버전에서 제거된다.

```diff
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: ...
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
```

### 3. `.gitignore`에 `dist/` 추가

goreleaser 산출물 디렉토리가 무시되지 않아 로컬 실행 시 untracked 파일로 남았다.

## 검증

릴리스 잡은 `main` 푸시에서만 도는 구조라 PR CI로는 검증되지 않는다. 그래서 로컬에서
릴리스 파이프라인을 실제로 돌렸다 (goreleaser v2.17.1):

```
$ goreleaser check
  • 1 configuration file(s) validated        ← deprecation 경고 사라짐

$ goreleaser release --snapshot --clean --skip=publish
  • building ... 6 targets (linux/darwin/windows × amd64/arm64)
  • archiving   pylon_..._linux_amd64.tar.gz
                pylon_..._darwin_arm64.tar.gz
                pylon_..._windows_amd64.zip     ← format_overrides 정상 동작
  • calculating checksums
  • release succeeded after 23s
```

`actionlint`도 통과.
